### PR TITLE
scatterplot: scale dot radius according to zoom level

### DIFF
--- a/example/examples/scatterplot.react.js
+++ b/example/examples/scatterplot.react.js
@@ -85,7 +85,9 @@ var ScatterplotOverlayExample = React.createClass({
         locations: locations,
         dotRadius: 2,
         globalOpacity: 1,
-        compositeOperation: 'screen'
+        compositeOperation: 'screen',
+        defaultZoom: 11,
+        zoom: this.state.zoom
       })
     ]);
   }

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -40,7 +40,9 @@ var ScatterplotOverlay = React.createClass({
     globalOpacity: React.PropTypes.number,
     dotRadius: React.PropTypes.number,
     dotFill: React.PropTypes.string,
-    compositeOperation: React.PropTypes.oneOf(COMPOSITE_TYPES)
+    compositeOperation: React.PropTypes.oneOf(COMPOSITE_TYPES),
+    defaultZoom: React.PropTypes.number,
+    zoom: React.PropTypes.number
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -70,7 +72,8 @@ var ScatterplotOverlay = React.createClass({
     var canvas = this.getDOMNode();
     var ctx = canvas.getContext('2d');
     var props = this.props;
-    var radius = this.props.dotRadius;
+    var scale = Math.pow(this.props.zoom / this.props.defaultZoom, 6);
+    var radius = this.props.dotRadius * scale;
     var fill = this.props.dotFill;
     ctx.save();
     ctx.scale(pixelRatio, pixelRatio);

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -73,6 +73,9 @@ var ScatterplotOverlay = React.createClass({
     var ctx = canvas.getContext('2d');
     var props = this.props;
     var scale = Math.pow(this.props.zoom / this.props.defaultZoom, 6);
+    //dot doesn't scale according to the map zoom level:
+    //var radius = this.props.dotRadius;    
+    //dot scales according to zoom level:
     var radius = this.props.dotRadius * scale;
     var fill = this.props.dotFill;
     ctx.save();


### PR DESCRIPTION
Hi @vicapow , in the scatterplot example, the radius of dots remain the same regardless of map zoom level. 
I find it useful to scale it so as to keep pace with the map, especially if the radius represents some value, for example doing data visualization.

What do you think?

before
![before](http://i.imgur.com/rpwKgjf.png)

after
![after](http://i.imgur.com/W3JWBOV.png)
