### PR TITLE
Remove ReactDOM.findDOMNode calls from src

### DIFF
--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -20,7 +20,6 @@
 'use strict';
 
 var React = require('react');
-var ReactDOM = require('react-dom');
 var MapboxGL = require('mapbox-gl');
 var Point = MapboxGL.Point;
 var document = require('global/document');
@@ -79,7 +78,7 @@ var MapInteractions = React.createClass({
   },
 
   _getMousePos: function _getMousePos(event) {
-    var el = ReactDOM.findDOMNode(this.refs.container);
+    var el = this.refs.container;
     return mousePos(el, event);
   },
 

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -21,7 +21,6 @@
 
 var assert = require('assert');
 var React = require('react');
-var ReactDOM = require('react-dom');
 var debounce = require('debounce');
 var r = require('r-dom');
 var d3 = require('d3');
@@ -253,7 +252,7 @@ var MapGL = React.createClass({
       mapStyle = this.props.mapStyle;
     }
     var map = new MapboxGL.Map({
-      container: ReactDOM.findDOMNode(this.refs.mapboxMap),
+      container: this.refs.mapboxMap,
       center: [this.state.longitude, this.state.latitude],
       zoom: this.state.zoom,
       style: mapStyle,

--- a/src/overlays/canvas.react.js
+++ b/src/overlays/canvas.react.js
@@ -20,7 +20,6 @@
 'use strict';
 
 var React = require('react');
-var ReactDOM = require('react-dom');
 var window = require('global/window');
 var r = require('r-dom');
 
@@ -49,7 +48,7 @@ var CanvasOverlay = React.createClass({
 
   _redraw: function _redraw() {
     var pixelRatio = devicePixelRatio();
-    var canvas = ReactDOM.findDOMNode(this);
+    var canvas = this.refs.overlay;
     var ctx = canvas.getContext('2d');
     ctx.save();
     ctx.scale(pixelRatio, pixelRatio);

--- a/src/overlays/choropleth.react.js
+++ b/src/overlays/choropleth.react.js
@@ -20,7 +20,6 @@
 'use strict';
 
 var React = require('react');
-var ReactDOM = require('react-dom');
 var window = require('global/window');
 var d3 = require('d3');
 var r = require('r-dom');
@@ -71,7 +70,7 @@ var ChoroplethOverlay = React.createClass({
 
   _redraw: function _redraw() {
     var pixelRatio = window.devicePixelRatio;
-    var canvas = ReactDOM.findDOMNode(this);
+    var canvas = this.refs.overlay;
     var ctx = canvas.getContext('2d');
     var project = this.props.project;
 

--- a/src/overlays/draggable-points.react.js
+++ b/src/overlays/draggable-points.react.js
@@ -21,7 +21,6 @@
 
 var assign = require('object-assign');
 var React = require('react');
-var ReactDOM = require('react-dom');
 var Immutable = require('immutable');
 var r = require('r-dom');
 var transform = require('svg-transform');
@@ -78,7 +77,7 @@ var DraggablePointsOverlay = React.createClass({
 
   _onDrag: function _onDrag(event) {
     event.stopPropagation();
-    var pixel = mouse(ReactDOM.findDOMNode(this.refs.container), event);
+    var pixel = mouse(this.refs.container, event);
     var latlng = this.props.unproject(pixel);
     this.props.onUpdatePoint({
       key: this.state.draggedPointKey,
@@ -96,7 +95,7 @@ var DraggablePointsOverlay = React.createClass({
   _addPoint: function _addPoint(event) {
     event.stopPropagation();
     event.preventDefault();
-    var pixel = mouse(ReactDOM.findDOMNode(this.refs.container), event);
+    var pixel = mouse(this.refs.container, event);
     var location = this.props.unproject(pixel);
     this.props.onAddPoint([location.lat, location.lng]);
   },

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -20,7 +20,6 @@
 'use strict';
 
 var React = require('react');
-var ReactDOM = require('react-dom');
 var window = require('global/window');
 var d3 = require('d3');
 var r = require('r-dom');
@@ -68,7 +67,7 @@ var ScatterplotOverlay = React.createClass({
 
   _redraw: function _redraw() {
     var pixelRatio = window.devicePixelRatio;
-    var canvas = ReactDOM.findDOMNode(this);
+    var canvas = this.refs.overlay;
     var ctx = canvas.getContext('2d');
     var props = this.props;
     var radius = this.props.dotRadius;


### PR DESCRIPTION
Per the react docs, this use case is discouraged and can be
replaced with the ref itself. It also allows the removal of
ReactDOM from the src require statements

https://facebook.github.io/react/docs/top-level-api.html#reactdom.finddomnode