### PR TITLE
Update budo to latest version and get example working again

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -31,7 +31,6 @@ var CustomExample = require('./examples/custom.react');
 var GeodataCreator = require('./examples/geodata-creator.react');
 var ScatterplotExample = require('./examples/scatterplot.react');
 var RouteExample = require('./examples/route.react');
-var process = require('process');
 
 function getAccessToken() {
   var match = window.location.search.match(/access_token=([^&\/]*)/);

--- a/package.json
+++ b/package.json
@@ -30,18 +30,18 @@
   },
   "devDependencies": {
     "bistre": "^1.0.1",
-    "budo": "^4.2.1",
+    "budo": "^8.0.0",
     "envify": "^3.4.0",
+    "immutable": "^3.7.3",
     "opn": "^3.0.2",
     "prova": "^2.1.2",
-    "react-dom": "0.14.x",
-    "uber-standard": "^5.1.0",
-    "immutable": "^3.7.3",
     "r-dom": "^2.1.0",
-    "react": "0.14.x"
+    "react": "0.14.x",
+    "react-dom": "0.14.x",
+    "uber-standard": "^5.1.0"
   },
   "scripts": {
-    "start": "budo ./example/main.js --live -- -t envify | bistre",
+    "start": "budo ./example/main.js --live -- -t envify",
     "lint": "uber-standard",
     "test": "npm run lint && prova -q -b -t envify -l chrome test/*",
     "precommit": "npm run lint -s",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "viewport-mercator-project": "^2.0.1"
   },
   "devDependencies": {
-    "bistre": "^1.0.1",
     "budo": "^8.0.0",
     "envify": "^3.4.0",
     "immutable": "^3.7.3",


### PR DESCRIPTION
- Ran `npm install budo@latest --save-dev` (this adds a bit of commit noise since it re-orders deps)
- Removed `bistre` since budo includes its own built-in pretty-printer which tends to look nicer
- Removed the `require('process')` line since it seems to break with latest browserify; should instead just assume it exists globally like in Node.

Budo has lots of improvements/fixes since v4, you can see them all [here](https://github.com/mattdesl/budo/blob/master/CHANGELOG.md). Cheers! :tada: