### PR TITLE
Feature/efficient updating of geojson sources

### DIFF
--- a/src/map.react.js
+++ b/src/map.react.js
@@ -63,7 +63,7 @@ function updateSource(map, update) {
 
     if (newSource.type === "geojson") {
         var oldSource = map.getSource(update.id);
-        if (oldSource.type === "geojson") {
+        if (oldSource.setData != null) {
             oldSource.setData(newSource.data);
             return;
         }

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -58,6 +58,21 @@ function cloneTransform(original) {
   return transform;
 }
 
+function updateSource(map, update) {
+    var newSource = update.source.toJS();
+
+    if (newSource.type === "geojson") {
+        var oldSource = map.getSource(update.id);
+        if (oldSource.type === "geojson") {
+            oldSource.setData(newSource.data);
+            return;
+        }
+    }
+    
+    map.removeSource(update.id);
+    map.addSource(update.id, newSource);   
+}
+
 var MapGL = React.createClass({
 
   displayName: 'MapGL',
@@ -413,8 +428,7 @@ var MapGL = React.createClass({
         map.addSource(enter.id, enter.source.toJS());
       });
       sourcesDiff.update.forEach(function each(update) {
-        map.removeSource(update.id);
-        map.addSource(update.id, update.source.toJS());
+        updateSource(map, update);
       });
       sourcesDiff.exit.forEach(function each(exit) {
         map.removeSource(exit.id);


### PR DESCRIPTION
Currently GeoJSON sources get updated by removing the old source, and adding the new source: but this is many times slower than calling setData. This PR updates it to use setData for GeoJSON sources (as long as they haven't changed type), and the old method for all other sources.
