### PR TITLE
Fix bug in batched source/layer updates

### DIFF
--- a/src/map.react.js
+++ b/src/map.react.js
@@ -414,29 +414,29 @@ var MapGL = React.createClass({
       return;
     }
 
-    map.batch(function batchStyleUpdates() {
+    map.batch(function batchStyleUpdates(batch) {
       sourcesDiff.enter.forEach(function each(enter) {
-        map.addSource(enter.id, enter.source.toJS());
+        batch.addSource(enter.id, enter.source.toJS());
       });
       sourcesDiff.update.forEach(function each(update) {
-        map.removeSource(update.id);
-        map.addSource(update.id, update.source.toJS());
+        batch.removeSource(update.id);
+        batch.addSource(update.id, update.source.toJS());
       });
       sourcesDiff.exit.forEach(function each(exit) {
-        map.removeSource(exit.id);
+        batch.removeSource(exit.id);
       });
       layersDiff.exiting.forEach(function forEach(exit) {
         if (map.style.getLayer(exit.id)) {
-          map.removeLayer(exit.id);
+          batch.removeLayer(exit.id);
         }
       });
       layersDiff.updates.forEach(function forEach(update) {
         if (!update.enter) {
           // This is an old layer that needs to be updated. Remove the old layer
           // with the same id and add it back again.
-          map.removeLayer(update.id);
+          batch.removeLayer(update.id);
         }
-        map.addLayer(update.layer.toJS(), update.before);
+        batch.addLayer(update.layer.toJS(), update.before);
       });
     });
   },


### PR DESCRIPTION
_setDiffStyle called map.batch but didn't use the "style_batch" argument
that it receives in order to batch updates to layers and sources. This
caused one "_broadcastLayers" call in mapbox-gl per changed source or layer,
which is very slow in some cases.

Example usage from mapbox-gl docs: https://www.mapbox.com/mapbox-gl-js/api/#Map.batch