### PR TITLE
Upgrade D3 to version 4

### DIFF
--- a/example/examples/custom.react.js
+++ b/example/examples/custom.react.js
@@ -21,7 +21,8 @@
 
 var assign = require('object-assign');
 var React = require('react');
-var d3 = require('d3');
+var d3Array = require('d3-array');
+var d3Random = require('d3-random');
 var window = require('global/window');
 var alphaify = require('alphaify');
 var transform = require('svg-transform');
@@ -36,14 +37,14 @@ var SVGOverlay = require('../../src/overlays/svg.react');
 var location = require('./../data/cities.json')[0];
 
 var wiggle = (function _wiggle() {
-  var normal = d3.random.normal();
+  var normal = d3Random.randomNormal();
   return function __wiggle(scale) {
     return normal() * scale;
   };
 }());
 
 // Example data.
-var locations = Immutable.fromJS(d3.range(30).map(function _map() {
+var locations = Immutable.fromJS(d3Array.range(30).map(function _map() {
   return [location.longitude + wiggle(0.01), location.latitude + wiggle(0.01)];
 }));
 

--- a/example/examples/route.react.js
+++ b/example/examples/route.react.js
@@ -21,7 +21,9 @@
 
 var assign = require('object-assign');
 var React = require('react');
-var d3 = require('d3');
+var d3Color = require('d3-color');
+var d3Scale = require('d3-scale');
+var round = require('../../src/utils.js').round;
 var r = require('r-dom');
 var alphaify = require('alphaify');
 var window = require('global/window');
@@ -33,7 +35,7 @@ var CanvasOverlay = require('../../src/overlays/canvas.react');
 
 var ROUTES = require('./../data/routes-example.json');
 
-var color = d3.scale.category10();
+var color = d3Scale.scaleCategory10();
 
 var RouteOverlayExample = React.createClass({
   displayName: 'RouteOverlayExample',
@@ -85,7 +87,7 @@ var RouteOverlayExample = React.createClass({
   _redrawSVGOverlay: function _redrawSVGOverlay(opt) {
     var routes = ROUTES.map(function _map(route, index) {
       var points = route.coordinates.map(opt.project).map(function __map(p) {
-        return [d3.round(p[0], 1), d3.round(p[1], 1)];
+        return [round(p[0], 1), round(p[1], 1)];
       });
       return r.g({key: index}, this._renderRoute(points, index));
     }, this);
@@ -99,8 +101,8 @@ var RouteOverlayExample = React.createClass({
     ctx.clearRect(0, 0, width, height);
     ROUTES.map(function _map(route, index) {
       route.coordinates.map(opt.project).forEach(function _forEach(p, i) {
-        var point = [d3.round(p[0], 1), d3.round(p[1], 1)];
-        ctx.fillStyle = d3.rgb(color(index)).brighter(1).toString();
+        var point = [round(p[0], 1), round(p[1], 1)];
+        ctx.fillStyle = d3Color.rgb(color(index)).brighter(1).toString();
         ctx.beginPath();
         ctx.arc(point[0], point[1], 2, 0, Math.PI * 2);
         ctx.fill();

--- a/example/examples/scatterplot.react.js
+++ b/example/examples/scatterplot.react.js
@@ -23,7 +23,8 @@ var assign = require('object-assign');
 var React = require('react');
 var r = require('r-dom');
 var Immutable = require('immutable');
-var d3 = require('d3');
+var d3Array = require('d3-array');
+var d3Random = require('d3-random');
 
 var MapGL = require('../../src/index.js');
 var ScatterplotOverlay = require('../../src/overlays/scatterplot.react');
@@ -31,13 +32,13 @@ var ScatterplotOverlay = require('../../src/overlays/scatterplot.react');
 // San Francisco
 var location = require('./../data/cities.json')[0];
 
-var normal = d3.random.normal();
+var normal = d3Random.randomNormal();
 function wiggle(scale) {
   return normal() * scale;
 }
 
 // Example data.
-var locations = Immutable.fromJS(d3.range(4000).map(function _map() {
+var locations = Immutable.fromJS(d3Array.range(4000).map(function _map() {
   return [location.longitude + wiggle(0.01), location.latitude + wiggle(0.01)];
 }));
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "alphaify": "^1.0.0",
+    "alphaify": "samhogg/alphaify#remove-d3@3",
     "bowser": "^1.0.0",
     "canvas-composite-types": "^1.0.4",
-    "d3": "^3.5.16",
+    "d3-array": "^0.7.1",
+    "d3-color": "^0.4.2",
+    "d3-scale": "^0.6.4",
     "global": "^4.3.0",
     "keymirror": "^0.1.1",
     "mapbox-gl": "0.14.1",
@@ -30,6 +32,7 @@
   },
   "devDependencies": {
     "budo": "^8.0.4",
+    "d3-random": "^0.2.1",
     "envify": "^3.4.0",
     "immutable": "^3.7.6",
     "opn": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "alphaify": "samhogg/alphaify#remove-d3@3",
+    "alphaify": "^2.0.0",
     "bowser": "^1.0.0",
     "canvas-composite-types": "^1.0.4",
     "d3-array": "^0.7.1",

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -22,7 +22,6 @@
 var assert = require('assert');
 var React = require('react');
 var r = require('r-dom');
-var d3 = require('d3');
 var assign = require('object-assign');
 var Immutable = require('immutable');
 var mapboxgl = require('mapbox-gl');
@@ -264,7 +263,7 @@ var MapGL = React.createClass({
       // attributionControl: this.props.attributionControl
     });
 
-    d3.select(map.getCanvas()).style('outline', 'none');
+    map.getCanvas().style.outline = 'none'
 
     this._map = map;
     this._updateMapViewport();

--- a/src/overlays/choropleth.react.js
+++ b/src/overlays/choropleth.react.js
@@ -22,7 +22,8 @@
 var React = require('react');
 var ViewportMercator = require('viewport-mercator-project');
 var window = require('global/window');
-var d3 = require('d3');
+var d3Array = require('d3-array');
+var d3Scale = require('d3-scale');
 var r = require('r-dom');
 var Immutable = require('immutable');
 
@@ -86,8 +87,8 @@ var ChoroplethOverlay = React.createClass({
     }
 
     if (this.props.renderWhileDragging || !this.props.isDragging) {
-      var transform = d3.geo.transform({point: projectPoint});
-      var path = d3.geo.path().projection(transform).context(ctx);
+      // var transform = d3.geo.transform({point: projectPoint});
+      // var path = d3.geo.path().projection(transform).context(ctx);
       this._drawFeatures(ctx, path);
     }
     ctx.restore();
@@ -100,9 +101,9 @@ var ChoroplethOverlay = React.createClass({
       return;
     }
     if (!colorDomain) {
-      colorDomain = d3.extent(features.toArray(), this.props.valueAccessor);
+      colorDomain = d3Array.extent(features.toArray(), this.props.valueAccessor);
     }
-    var colorScale = d3.scale.linear()
+    var colorScale = d3Scale.scaleLinear()
       .domain(colorDomain)
       .range(this.props.colorRange)
       .clamp(true);

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -21,8 +21,8 @@
 
 var React = require('react');
 var window = require('global/window');
-var d3 = require('d3');
 var r = require('r-dom');
+var round = require('../utils.js').round;
 var Immutable = require('immutable');
 var COMPOSITE_TYPES = require('canvas-composite-types');
 var ViewportMercator = require('viewport-mercator-project');
@@ -86,7 +86,7 @@ var ScatterplotOverlay = React.createClass({
     ) {
       this.props.locations.forEach(function _forEach(location) {
         var pixel = mercator.project(this.props.lngLatAccessor(location));
-        var pixelRounded = [d3.round(pixel[0], 1), d3.round(pixel[1], 1)];
+        var pixelRounded = [round(pixel[0], 1), round(pixel[1], 1)];
         if (pixelRounded[0] + radius >= 0 &&
             pixelRounded[0] - radius < props.width &&
             pixelRounded[1] + radius >= 0 &&

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,6 +26,14 @@ function relativeMousePosition(container, event) {
   return [x, y];
 }
 
+// From d3v3 d3.round
+function round(x, n) {
+  return n
+      ? Math.round(x * (n = Math.pow(10, n))) / n
+      : Math.round(x);
+}
+
 module.exports = {
-  relativeMousePosition: relativeMousePosition
+  relativeMousePosition: relativeMousePosition,
+  round: round
 };


### PR DESCRIPTION
Here's an initial cut at #34

* Used d3 modules where appropriate
* Added round function to utils, d3@4 doesn't have it yet
* TODO - find a replacement for d3.geo in choropleth.react.js
  This might be coming soon - although https://github.com/d3/d3-geo
  is currently empty.
* TODO - use alphaify from `npm` rather than my fork [(relies on this PR being merged)](https://github.com/vicapow/alphaify/pull/1)

Obviously the d3.geo part is a blocker at the moment, but the other changes are pretty straightforward.