### PR TITLE
Revert "Add props for bearing and pitch"

### DIFF
--- a/src/map.react.js
+++ b/src/map.react.js
@@ -172,17 +172,7 @@ var MapGL = React.createClass({
       * There are still known issues with style diffing. As a temporary stopgap,
       * add the option to prevent style diffing.
       */
-    preventStyleDiffing: React.PropTypes.bool,
-
-    /**
-      * Specify the bearing of the viewport
-      */
-    bearing: React.PropTypes.number,
-
-    /**
-      * Specify the pitch of the viewport
-      */
-    pitch: React.PropTypes.number
+    preventStyleDiffing: React.PropTypes.bool
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -303,8 +293,8 @@ var MapGL = React.createClass({
       this._getMap().jumpTo({
         center: [state.longitude, state.latitude],
         zoom: state.zoom,
-        bearing: this.props.bearing || 0,
-        pitch: this.props.pitch || 0
+        bearing: 0,
+        pitch: 0
       });
     }
     if (state.width !== state.prevWidth || state.height !== state.prevHeight) {


### PR DESCRIPTION
Reverts uber/react-map-gl#73 per discussion with @vicapow.

Let's develop the feature fully rather than merge partial support. 