### PR TITLE
Bump mapbox-gl version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "d3": "^3.5.16",
     "global": "^4.3.0",
     "keymirror": "^0.1.1",
-    "mapbox-gl": "0.20.0",
+    "mapbox-gl": "0.21.0",
     "pure-render-decorator": "^1.1.0",
     "svg-transform": "0.0.3",
     "tap-browser-color": "^0.1.2",


### PR DESCRIPTION
Adds a number of features, including the `{quadkey}` tile URL parameter: https://github.com/mapbox/mapbox-gl-js/releases
