### PR TITLE
add onLoad event handler

### DIFF
--- a/src/map.react.js
+++ b/src/map.react.js
@@ -152,7 +152,13 @@ const PROP_TYPES = {
     * Unit: map heights, default 1.5
     * Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
     */
-  altitude: React.PropTypes.number
+  altitude: React.PropTypes.number,
+
+  /**
+    * `onLoad` callback is fired on the first complete render,
+    * when all dependencies have been loaded
+    */
+  onLoad: PropTypes.func
 };
 
 const DEFAULT_PROPS = {
@@ -197,6 +203,10 @@ export default class MapGL extends Component {
       // TODO?
       // attributionControl: this.props.attributionControl
     });
+
+    if (this.props.onLoad) {
+      map.once('load', this.props.onLoad);
+    }
 
     d3.select(map.getCanvas()).style('outline', 'none');
 

--- a/test/map-spec.js
+++ b/test/map-spec.js
@@ -29,5 +29,25 @@ test('MapGL', function(t) {
     t.ok(true);
     t.end();
   });
+  t.test('Calls onLoad', function(t) {
+    t.ok(MapGL);
+    const map = (
+      <MapGL
+        width={ 500 }
+        height={ 500 }
+        longitude={ -122 }
+        latitude={ 37 }
+        zoom={ 14 }
+        onLoad={ () => {
+          t.ok(true);
+          t.end();
+        } }
+        mapboxApiAccessToken={ mapboxApiAccessToken }/>
+    );
+    const reactContainer = document.createElement('div');
+    document.body.appendChild(reactContainer);
+    ReactDOM.render(map, reactContainer);
+    t.ok(true);
+  });
 });
 /* eslint-enable func-names */


### PR DESCRIPTION
adds a new property `onLoad` for handling the mapbox-gl-js `load` event. very useful if you don't want to show the map or want to show a loading indicator until all tiles and data sources have been loaded.
