### PR TITLE
Add a stateful wrapper to react map gl

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,9 @@
 import MapGL from './map.react';
 import * as overlays from './overlays';
 import fitBounds from './utils/fit-bounds';
+import StatefulMapGL from './stateful-map.react';
 
 module.exports = MapGL;
+module.exports.StatefulMapGL = StatefulMapGL;
 module.exports.fitBounds = fitBounds;
 Object.assign(module.exports, overlays);

--- a/src/stateful-map.react.js
+++ b/src/stateful-map.react.js
@@ -1,0 +1,117 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import React, {PropTypes, Component} from 'react';
+import autobind from 'autobind-decorator';
+import pureRender from 'pure-render-decorator';
+import MapGL from './map.react';
+
+function noop() {}
+
+const PUBLIC_MAP_STATE_DEFAULTS = {
+  latitude: 0,
+  longitude: 0,
+  zoom: 11,
+  pitch: 0,
+  bearing: 0,
+  altitude: 1.5
+};
+
+function compareProps(refObject, newObject) {
+  for (const field in refObject) {
+    if (!(field in newObject) || refObject[field] !== newObject[field]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const PROP_TYPES = {
+  /**
+    * `onChangeViewport` callback is fired when the user interacted with the
+    * map. The object passed to the callback contains `latitude`,
+    * `longitude`, `zoom` and additional information.
+    */
+  onChangeViewport: PropTypes.func
+};
+
+const DEFAULT_PROPS = {
+  onChangeViewport: noop
+};
+
+@pureRender
+export default class StatefulMapGL extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = this._getInternalMapState(props);
+  }
+
+  // Extract all public map state fields from an object
+  _getPublicMapState(props) {
+    return {
+      ...PUBLIC_MAP_STATE_DEFAULTS,
+      latitude: props.latitude,
+      longitude: props.longitude,
+      zoom: props.zoom,
+      pitch: props.pitch,
+      bearing: props.bearing,
+      altitude: props.altitude
+    };
+  }
+
+  // Extract all non-public map state fields from an object
+  _getInternalMapState(props) {
+    return {
+      isDragging: props.isDragging || false,
+      startDragLngLat: props.startDragLngLat || null,
+      startBearing: props.startBearing || null,
+      startPitch: props.startPitch || null
+    };
+  }
+
+  // Save internal props to state
+  // Call apps onChangeViewport with public props only
+  // Only call app if public props have changed.
+  @autobind _onChangeViewport(mapState) {
+    // Update state (triggering map redraw) only if internal props changed
+    const internalMapState = this._getInternalMapState(mapState);
+    if (!compareProps(internalMapState, this.state)) {
+      this.setState(internalMapState);
+    }
+
+    // Update app (presumably triggering redraw) only if map changed vs props
+    const publicMapState = this._getPublicMapState(mapState);
+    if (!compareProps(publicMapState, this.props)) {
+      this.props.onChangeViewport(publicMapState);
+    }
+  }
+
+  render() {
+    return (
+      <MapGL
+        { ...this.props }
+        { ...this.state }
+        onChangeViewport={ this._onChangeViewport }/>
+    );
+  }
+}
+
+StatefulMapGL.propTypes = PROP_TYPES;
+StatefulMapGL.defaultProps = DEFAULT_PROPS;

--- a/test/map-spec.js
+++ b/test/map-spec.js
@@ -3,7 +3,7 @@ import document from 'global/document';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import test from 'tape-catch';
-import MapGL from '../src';
+import MapGL, {StatefulMapGL} from '../src';
 
 /* eslint-disable no-process-env */
 // This will get converted to a string by envify
@@ -14,6 +14,7 @@ const mapboxApiAccessToken = process.env.MapboxAccessToken;
 test('MapGL', function(t) {
   t.test('Exists', function(t) {
     t.ok(MapGL);
+
     const map = (
       <MapGL
         width={ 500 }
@@ -23,10 +24,35 @@ test('MapGL', function(t) {
         zoom={ 14 }
         mapboxApiAccessToken={ mapboxApiAccessToken }/>
     );
+
     const reactContainer = document.createElement('div');
     document.body.appendChild(reactContainer);
     ReactDOM.render(map, reactContainer);
-    t.ok(true);
+    t.ok(map);
+    t.end();
+  });
+});
+/* eslint-enable func-names */
+
+/* eslint-disable func-names, no-shadow */
+test('StatefulMapGL', function(t) {
+  t.test('Exists', function(t) {
+    t.ok(StatefulMapGL);
+
+    const map = (
+      <StatefulMapGL
+        width={ 500 }
+        height={ 500 }
+        longitude={ -122 }
+        latitude={ 37 }
+        zoom={ 14 }
+        mapboxApiAccessToken={ mapboxApiAccessToken }/>
+    );
+
+    const reactContainer = document.createElement('div');
+    document.body.appendChild(reactContainer);
+    ReactDOM.render(map, reactContainer);
+    t.ok(map);
     t.end();
   });
 });


### PR DESCRIPTION
An optional wrapper.

Minimizes the amount of callback handling and state-keeping required by the application.

Use case: optimizes rendering in some of our applications, especially during startup, where eliminating just a couple of rerenders (map + overlay stack) can make a noticeable difference.

@vicapow 
