### PR TITLE
fixed GeoJSONSource updating, broken when upgrading to mapbox-gl v0.24.0

### DIFF
--- a/src/map.react.js
+++ b/src/map.react.js
@@ -276,21 +276,22 @@ export default class MapGL extends Component {
     const newSource = update.source.toJS();
     if (newSource.type === 'geojson') {
       const oldSource = map.getSource(update.id);
-      if (oldSource instanceof mapboxgl.GeoJSONSource) {
+      if (oldSource.type === 'geojson') {
         // update data if no other GeoJSONSource options were changed
+        const oldOpts = oldSource.workerOptions
         if (
           (newSource.maxzoom === undefined ||
-            newSource.maxzoom === oldSource.geojsonVtOptions.maxZoom) &&
+            newSource.maxzoom === oldOpts.geojsonVtOptions.maxZoom) &&
           (newSource.buffer === undefined ||
-            newSource.buffer === oldSource.geojsonVtOptions.buffer) &&
+            newSource.buffer === oldOpts.geojsonVtOptions.buffer) &&
           (newSource.tolerance === undefined ||
-            newSource.tolerance === oldSource.geojsonVtOptions.tolerance) &&
+            newSource.tolerance === oldOpts.geojsonVtOptions.tolerance) &&
           (newSource.cluster === undefined ||
-            newSource.cluster === oldSource.cluster) &&
+            newSource.cluster === oldOpts.cluster) &&
           (newSource.clusterRadius === undefined ||
-            newSource.clusterRadius === oldSource.superclusterOptions.radius) &&
+            newSource.clusterRadius === oldOpts.superclusterOptions.radius) &&
           (newSource.clusterMaxZoom === undefined ||
-            newSource.clusterMaxZoom === oldSource.superclusterOptions.maxZoom)
+            newSource.clusterMaxZoom === oldOpts.superclusterOptions.maxZoom)
         ) {
           oldSource.setData(newSource.data);
           return;


### PR DESCRIPTION
The change applied in #124 has broken when updating to the latest Mapbox GL JS. I just tried out v1.6.0, and immediately noticed that it throws an error when updating GeoJSON sources. The cause of this is that when upgrading from [Mapbox GL JS v0.21.0 to v0.22.0](https://github.com/mapbox/mapbox-gl-js/blob/master/CHANGELOG.md#0220-august-11-2016), they made `GeoJSONSource` private, along with some other refactoring, so we can no longer check for an `instanceof` it. I have it fixed now against Mapbox GL JS v0.24.0.