### PR TITLE
Provide a way to control per-layer interactivity

### DIFF
--- a/src/map.react.js
+++ b/src/map.react.js
@@ -93,11 +93,16 @@ const PROP_TYPES = {
     */
   startDragLngLat: PropTypes.array,
   /**
-    * Called when a feature is hovered over. Features must set the
-    * `interactive` property to `true` for this to work properly. see the
-    * Mapbox example: https://www.mapbox.com/mapbox-gl-js/example/featuresat/
-    * The first argument of the callback will be the array of feature the
-    * mouse is over. This is the same response returned from `featuresAt`.
+    * Called when a feature is hovered over. Uses Mapbox's
+    * queryRenderedFeatures API to find features under the pointer:
+    * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+    * To query only some of the layers, set the `interactive` property in the
+    * layer style to `true`. See Mapbox's style spec
+    * https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
+    * If no interactive layers are found (e.g. using Mapbox's default styles),
+    * will fall back to query all layers.
+    * @callback
+    * @param {array} features - The array of features the mouse is over.
     */
   onHoverFeatures: PropTypes.func,
   /**
@@ -114,11 +119,14 @@ const PROP_TYPES = {
   attributionControl: PropTypes.bool,
 
   /**
-    * Called when a feature is clicked on. Features must set the
-    * `interactive` property to `true` for this to work properly. see the
-    * Mapbox example: https://www.mapbox.com/mapbox-gl-js/example/featuresat/
-    * The first argument of the callback will be the array of feature the
-    * mouse is over. This is the same response returned from `featuresAt`.
+    * Called when a feature is clicked on. Uses Mapbox's
+    * queryRenderedFeatures API to find features under the pointer:
+    * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+    * To query only some of the layers, set the `interactive` property in the
+    * layer style to `true`. See Mapbox's style spec
+    * https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
+    * If no interactive layers are found (e.g. using Mapbox's default styles),
+    * will fall back to query all layers.
     */
   onClickFeatures: PropTypes.func,
 

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -313,7 +313,7 @@ export default class MapGL extends Component {
     const interactiveLayerIds = Array.isArray(mapStyle.layers) ? mapStyle.layers
       .filter(l => l.interactive)
       .map(l => l.id) : [];
-    this._queryParameters = interactiveLayerIds.length === 0 ? {} :
+    this._queryParams = interactiveLayerIds.length === 0 ? {} :
       {layers: interactiveLayerIds};
   }
 
@@ -565,7 +565,7 @@ export default class MapGL extends Component {
       return;
     }
     const features = map.queryRenderedFeatures([pos.x, pos.y],
-      this._queryParameters);
+      this._queryParams);
     if (!features.length && this.props.ignoreEmptyFeatures) {
       return;
     }
@@ -595,7 +595,7 @@ export default class MapGL extends Component {
     // Radius enables point features, like marker symbols, to be clicked.
     const size = this.props.clickRadius;
     const bbox = [[pos.x - size, pos.y - size], [pos.x + size, pos.y + size]];
-    const features = map.queryRenderedFeatures(bbox, this._queryParameters);
+    const features = map.queryRenderedFeatures(bbox, this._queryParams);
     if (!features.length && this.props.ignoreEmptyFeatures) {
       return;
     }

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -305,6 +305,8 @@ export default class MapGL extends Component {
     map.addSource(update.id, newSource);
   }
 
+  // Hover and click only query layers whose interactive property is true
+  // If no interactivity is specified, query all layers
   _updateQueryParams(mapStyle) {
     if (mapStyle instanceof Immutable.Map) {
       mapStyle = mapStyle.toJS();

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -29,6 +29,7 @@ import assert from 'assert';
 import MapInteractions from './map-interactions.react';
 import config from './config';
 
+import {getInteractiveLayerIds} from './utils/style-utils';
 import diffStyles from './utils/diff-styles';
 import {mod, unprojectFromTransform, cloneTransform} from './utils/transform';
 
@@ -202,7 +203,7 @@ export default class MapGL extends Component {
   }
 
   componentDidMount() {
-    const mapStyle = this.props.mapStyle instanceof Immutable.Map ?
+    const mapStyle = Immutable.Map.isMap(this.props.mapStyle) ?
       this.props.mapStyle.toJS() :
       this.props.mapStyle;
     const map = new mapboxgl.Map({
@@ -308,13 +309,7 @@ export default class MapGL extends Component {
   // Hover and click only query layers whose interactive property is true
   // If no interactivity is specified, query all layers
   _updateQueryParams(mapStyle) {
-    if (mapStyle instanceof Immutable.Map) {
-      mapStyle = mapStyle.toJS();
-    }
-
-    const interactiveLayerIds = Array.isArray(mapStyle.layers) ? mapStyle.layers
-      .filter(l => l.interactive)
-      .map(l => l.id) : [];
+    const interactiveLayerIds = getInteractiveLayerIds(mapStyle);
     this._queryParams = interactiveLayerIds.length === 0 ? {} :
       {layers: interactiveLayerIds};
   }
@@ -391,7 +386,7 @@ export default class MapGL extends Component {
     const mapStyle = newProps.mapStyle;
     const oldMapStyle = oldProps.mapStyle;
     if (mapStyle !== oldMapStyle) {
-      if (mapStyle instanceof Immutable.Map) {
+      if (Immutable.Map.isMap(mapStyle)) {
         if (this.props.preventStyleDiffing) {
           this._getMap().setStyle(mapStyle.toJS());
         } else {

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -310,9 +310,11 @@ export default class MapGL extends Component {
       mapStyle = mapStyle.toJS();
     }
 
-    this._queryParameters = Array.isArray(mapStyle.layers) ?
-      {layers: mapStyle.layers.filter(l => l.interactive).map(l => l.id)} :
-      {};
+    const interactiveLayerIds = Array.isArray(mapStyle.layers) ? mapStyle.layers
+      .filter(l => l.interactive)
+      .map(l => l.id) : [];
+    this._queryParameters = interactiveLayerIds.length === 0 ? {} :
+      {layers: interactiveLayerIds};
   }
 
   // Individually update the maps source and layers that have changed if all

--- a/src/utils/style-utils.js
+++ b/src/utils/style-utils.js
@@ -1,0 +1,17 @@
+import {Map} from 'immutable';
+
+export function getInteractiveLayerIds(mapStyle) {
+  let interactiveLayerIds = [];
+
+  if (Map.isMap(mapStyle) && mapStyle.has('layers')) {
+    interactiveLayerIds = mapStyle.get('layers')
+      .filter(l => l.get('interactive'))
+      .map(l => l.get('id'))
+      .toJS();
+  } else if (Array.isArray(mapStyle.layers)) {
+    interactiveLayerIds = mapStyle.layers.filter(l => l.interactive)
+      .map(l => l.id);
+  }
+
+  return interactiveLayerIds;
+}


### PR DESCRIPTION
https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures

ReactMapGL was calling mapbox's queryRenderedFeatures API without passing any filtering parameters. Features on all layers are returned as a result.

Without asking the user to provide a separate prop, we may only query layers whose interactive property is set to true, as suggested by the documentation for **onHoverFeatures** and **onClickFeatures**. In the case where no layers have this property specified (e.g. using Mapbox's default styles), we fall back to querying all layers. 

@vicapow @ibgreen