### PR TITLE
Provide prop for simple disabling of 'scroll zoom' behaviour

### DIFF
--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -70,7 +70,7 @@ const PROP_TYPES = {
   onTouchEnd: PropTypes.func,
   onZoom: PropTypes.func,
   onZoomEnd: PropTypes.func,
-  scrollZoom: PropTypes.bool
+  scrollZoomDisabled: PropTypes.bool
 };
 
 const DEFAULT_PROPS = {
@@ -85,7 +85,7 @@ const DEFAULT_PROPS = {
   onTouchEnd: noop,
   onZoom: noop,
   onZoomEnd: noop,
-  scrollZoom: true
+  scrollZoomDisabled: false
 };
 
 export default class MapInteractions extends Component {
@@ -193,8 +193,8 @@ export default class MapInteractions extends Component {
     event.preventDefault();
 
     // If we have disabled scroll zoom
-    if (this.props.scrollZoom !== true) return;
-    
+    if (this.props.scrollZoomDisabled === true) return;
+
     let value = event.deltaY;
     // Firefox doubles the values on retina screens...
     if (firefox && event.deltaMode === window.WheelEvent.DOM_DELTA_PIXEL) {

--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -193,7 +193,9 @@ export default class MapInteractions extends Component {
     event.preventDefault();
 
     // If we have disabled scroll zoom
-    if (this.props.scrollZoomDisabled === true) return;
+    if (this.props.scrollZoomDisabled === true) {
+      return;
+    }
 
     let value = event.deltaY;
     // Firefox doubles the values on retina screens...

--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -69,7 +69,8 @@ const PROP_TYPES = {
   onTouchRotate: PropTypes.func,
   onTouchEnd: PropTypes.func,
   onZoom: PropTypes.func,
-  onZoomEnd: PropTypes.func
+  onZoomEnd: PropTypes.func,
+  scrollZoom: PropTypes.bool
 };
 
 const DEFAULT_PROPS = {
@@ -83,7 +84,8 @@ const DEFAULT_PROPS = {
   onTouchRotate: noop,
   onTouchEnd: noop,
   onZoom: noop,
-  onZoomEnd: noop
+  onZoomEnd: noop,
+  scrollZoom: true
 };
 
 export default class MapInteractions extends Component {
@@ -189,6 +191,10 @@ export default class MapInteractions extends Component {
   _onWheel(event) {
     event.stopPropagation();
     event.preventDefault();
+
+    // If we have disabled scroll zoom
+    if (this.props.scrollZoom !== true) return;
+    
     let value = event.deltaY;
     // Firefox doubles the values on retina screens...
     if (firefox && event.deltaMode === window.WheelEvent.DOM_DELTA_PIXEL) {

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -167,7 +167,13 @@ const PROP_TYPES = {
     * Unit: map heights, default 1.5
     * Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
     */
-  altitude: React.PropTypes.number
+  altitude: React.PropTypes.number,
+
+  /**
+   * Disable the default scroll zoom behaviour
+   * Default true
+   */
+  scrollZoom: React.PropTypes.bool
 };
 
 const DEFAULT_PROPS = {
@@ -180,7 +186,8 @@ const DEFAULT_PROPS = {
   bearing: 0,
   pitch: 0,
   altitude: 1.5,
-  clickRadius: 15
+  clickRadius: 15,
+  scrollZoom: true
 };
 
 @pureRender
@@ -657,6 +664,7 @@ export default class MapGL extends Component {
           onTouchEnd ={ this._onTouchEnd }
           onZoom ={ this._onZoom }
           onZoomEnd ={ this._onZoomEnd }
+          scrollZoom ={ this.props.scrollZoom }
           width ={ this.props.width }
           height ={ this.props.height }>
 

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -171,9 +171,9 @@ const PROP_TYPES = {
 
   /**
    * Disable the default scroll zoom behaviour
-   * Default true
+   * Default false
    */
-  scrollZoom: React.PropTypes.bool
+  scrollZoomDisabled: React.PropTypes.bool
 };
 
 const DEFAULT_PROPS = {
@@ -187,7 +187,7 @@ const DEFAULT_PROPS = {
   pitch: 0,
   altitude: 1.5,
   clickRadius: 15,
-  scrollZoom: true
+  scrollZoomDisabled: false
 };
 
 @pureRender
@@ -664,7 +664,7 @@ export default class MapGL extends Component {
           onTouchEnd ={ this._onTouchEnd }
           onZoom ={ this._onZoom }
           onZoomEnd ={ this._onZoomEnd }
-          scrollZoom ={ this.props.scrollZoom }
+          scrollZoomDisabled ={ this.props.scrollZoomDisabled }
           width ={ this.props.width }
           height ={ this.props.height }>
 


### PR DESCRIPTION
This merge will allow a new prop on MapGL "scrollZoomDisabled" boolean. It's default value is 'false', meaning the current behaviour is preserved. 

When the scrollZoomDisabled prop is set to 'true', the mouse scroll will no longer zoom in/out. 

This addresses a usability issue when you wish to scroll down the page in a web browser, but the react-map-gl MapGL component captures the scroll events.

Mapbox GL JS provides an API option to disable the zoom scroll handler. This merge will give the user the flexibility to disable this also.
