### PR TITLE
update mapbox-gl to v0.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "d3-scale": "^1.0.3",
     "d3-selection": "^1.0.2",
     "global": "^4.3.0",
-    "mapbox-gl": "0.24.0",
+    "mapbox-gl": "0.25.1",
     "pure-render-decorator": "^1.1.0",
     "svg-transform": "0.0.3",
     "viewport-mercator-project": "^2.0.1"


### PR DESCRIPTION
Hi there! Mapbox GL v0.25.1 out on September 30 (https://github.com/mapbox/mapbox-gl-js/blob/master/CHANGELOG.md), all tests are passed, so maybe we can update to this version?
