### PR TITLE
Adds `onClick` prop handler

### DIFF
--- a/example/examples/click.react.js
+++ b/example/examples/click.react.js
@@ -56,10 +56,15 @@ export default class ClickExample extends Component {
 
   @autobind
   _onClickFeatures(features) {
-      const placeNames = features
-        .filter(feature => feature.layer['source-layer'] === 'place_label')
-        .map(feature => feature.properties.name);
-      windowAlert(placeNames);
+    const placeNames = features
+      .filter(feature => feature.layer['source-layer'] === 'place_label')
+      .map(feature => feature.properties.name);
+    windowAlert(placeNames);
+  }
+
+  @autobind
+  _onClick(coordinates, pos) {
+    windowAlert(`${coordinates}\n${JSON.stringify(pos)}`);
   }
 
   render() {
@@ -70,7 +75,8 @@ export default class ClickExample extends Component {
     return (
       <MapGL { ...viewport }
           onChangeViewport={ this._onChangeViewport }
-          onClickFeatures={ this._onClickFeatures }/>
+          onClickFeatures={ this._onClickFeatures }
+          onClick={ this._onClick }/>
     );
   }
 }

--- a/example/examples/click.react.js
+++ b/example/examples/click.react.js
@@ -1,0 +1,78 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import window from 'global/window';
+const windowAlert = window.alert;
+
+import React, {PropTypes, Component} from 'react';
+import autobind from 'autobind-decorator';
+
+import MapGL from '../../src';
+
+const PROP_TYPES = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired
+};
+
+export default class ClickExample extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      viewport: {
+        latitude: 37.7736092599127,
+        longitude: -122.42312591099463,
+        zoom: 12.011557070552028,
+        startDragLngLat: null,
+        isDragging: false
+      }
+    };
+  }
+
+  @autobind
+  _onChangeViewport(viewport) {
+    if (this.props.onChangeViewport) {
+      return this.props.onChangeViewport(viewport);
+    }
+    this.setState({viewport});
+  }
+
+  @autobind
+  _onClickFeatures(features) {
+      const placeNames = features
+        .filter(feature => feature.layer['source-layer'] === 'place_label')
+        .map(feature => feature.properties.name);
+      windowAlert(placeNames);
+  }
+
+  render() {
+    const viewport = {
+      ...this.state.viewport,
+      ...this.props
+    };
+    return (
+      <MapGL { ...viewport }
+          onChangeViewport={ this._onChangeViewport }
+          onClickFeatures={ this._onClickFeatures }/>
+    );
+  }
+}
+
+ClickExample.propTypes = PROP_TYPES;

--- a/example/main.js
+++ b/example/main.js
@@ -32,6 +32,7 @@ import ScatterplotExample from './examples/scatterplot.react';
 import RouteExample from './examples/route.react';
 import StyleDiffingExample from './examples/style-diffing.react';
 import TiltExample from './examples/tilt.react';
+import ClickExample from './examples/click.react';
 
 function getAccessToken() {
   const match = window.location.search.match(/access_token=([^&\/]*)/);
@@ -82,6 +83,7 @@ export default class App extends Component {
         <GeodataCreator { ...common }/>
         <NotInteractiveExample { ...common }/>
         <StyleDiffingExample { ...common }/>
+        <ClickExample {...common }/>
       </div>
     );
   }


### PR DESCRIPTION
This PR adds a new prop to the component that allows to subscribe to click events on the map. The handler is called with the map coordinates (longitude / latitude) as well as with the screen coordinates (x / y).

A new example demonstrating the `onClick` property as well as the existing `onClickFeatures` was added.
