### PR TITLE
update webpack configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,11 @@ See the interactive docs at: https://uber.github.io/react-map-gl
 npm install react-map-gl --save
 ```
 
-**Note on Bundling:** react-map-gl is extensively tested with `browserify`,
-however several users have reported issues when bundling their apps using
-`webpack`. As a first step, please consult the
-[official mapbox webpack config](https://github.com/mapbox/mapbox-gl-js/blob/master/webpack.config.example.js).
-There is also some helpful information from  in the issues and a
-[request for help](https://github.com/uber/react-map-gl/issues/112).
+**Note on Bundling:** react-map-gl is extensively tested with `browserify`
+and `webpack` is not formally supported. Information on the Mapbox-gl-js
+suggested webpack configuration as it relates to this project can be found
+in this [request for help](https://github.com/uber/react-map-gl/issues/112).
+
 
 ### Usage
 


### PR DESCRIPTION
Update readme to reflect that Mapbox-gl-js has [dropped webpack support](https://github.com/mapbox/mapbox-gl-js/#using-mapbox-gl-js-with-other-module-systems). As such the official mapbox webpack config file linked to no longer exists.

The mention of historical issues might still have value to some users but have gotten pretty hairy (in my experience) and no longer reflect the mapbox-gl-js official approch.  As such I removed mention of them and believe the RFH represents the current best practice. 
