### PR TITLE
HTTPS-friendly tile source

### DIFF
--- a/common/stamen-map-style.js
+++ b/common/stamen-map-style.js
@@ -29,7 +29,7 @@ module.exports = Immutable.Map({
       type: 'raster',
       tileSize: 256,
       scheme: 'xyz',
-      tiles: ['http://tile.stamen.com/toner/{z}/{x}/{y}.png']
+      tiles: ['//tile.stamen.com/toner/{z}/{x}/{y}.png']
     }
   },
   layers: [


### PR DESCRIPTION
The documentation's examples fail to render when visiting the docs over HTTPS.  This is due to a Mixed Content error:
![image](https://cloud.githubusercontent.com/assets/897290/20377196/b2eda1fc-ac4a-11e6-8306-723f87e0746c.png)
