### PR TITLE
Ensure fitBounds doesn't return NaN zoom value

### DIFF
--- a/src/utils/fit-bounds.js
+++ b/src/utils/fit-bounds.js
@@ -51,7 +51,7 @@ export default function fitBounds(width, height, bounds, {
   const scaleY = (tr.height - padding * 2 - Math.abs(offset.y) * 2) / size.y;
 
   const center = tr.unproject(nw.add(se).div(2));
-  const zoom = tr.scaleZoom(tr.scale * Math.min(scaleX, scaleY));
+  const zoom = tr.scaleZoom(tr.scale * Math.abs(Math.min(scaleX, scaleY)));
   return {
     latitude: center.lat,
     longitude: center.lng,


### PR DESCRIPTION
This should fix the NaN zoom value in issue https://github.com/uber/react-map-gl/issues/130.