### PR TITLE
bump up babel-preset-stage-2 version to avoid build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-2": "^6.5.0",
+    "babel-preset-stage-2": "^6.18.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "budo": "^8.2.2",
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "build": "babel src -d dist --copy-files --source-maps inline",
-    "start": "budo ./example/main.js --live --open --port 3000 -- -t babelify -t envify",
+    "start": "budo ./example/main.js --live --open --port 9966 -- -t babelify -t envify",
     "lint": "eslint src example test",
     "test": "npm run lint && browserify -t babelify -t envify test/index.js | testron",
     "precommit": "npm run lint -s",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "viewport-mercator-project": "^2.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.7.0",
-    "babel-core": "^6.7.0",
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.18.0",
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",


### PR DESCRIPTION
- bump up babel-preset-stage-2 version to avoid build errors
- match `npm start` port to that in the `README`