### PR TITLE
update to mapbox-gl 0.29.0; add maxZoom as a prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "d3-scale": "^1.0.3",
     "d3-selection": "^1.0.2",
     "global": "^4.3.0",
-    "mapbox-gl": "0.26.0",
+    "mapbox-gl": "0.29.0",
     "pure-render-decorator": "^1.1.0",
     "svg-transform": "0.0.3",
     "viewport-mercator-project": "^2.0.1"

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -98,7 +98,7 @@ const PROP_TYPES = {
     * during dragging. Where the map is depends on where you first clicked on
     * the map.
     */
-  startDragLngLat: PropTypes.object,
+  startDragLngLat: PropTypes.array,
   /**
     * Called when a feature is hovered over. Uses Mapbox's
     * queryRenderedFeatures API to find features under the pointer:
@@ -550,7 +550,7 @@ export default class MapGL extends Component {
     const {lng, lat} = unprojectFromTransform(transform, new Point(...pos));
     this._callOnChangeViewport(transform, {
       isDragging: true,
-      startDragLngLat: {lng, lat},
+      startDragLngLat: [lng, lat],
       startBearing: transform.bearing,
       startPitch: transform.pitch
     });
@@ -566,7 +566,8 @@ export default class MapGL extends Component {
       'for mouse drag behavior to calculate where to position the map.');
 
     const transform = cloneTransform(this._map.transform);
-    transform.setLocationAtPoint(this.props.startDragLngLat, new Point(...pos));
+    const [lng, lat] = this.props.startDragLngLat;
+    transform.setLocationAtPoint({lng, lat}, new Point(...pos));
     this._callOnChangeViewport(transform, {isDragging: true});
   }
 

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -54,6 +54,13 @@ const PROP_TYPES = {
     */
   zoom: PropTypes.number.isRequired,
   /**
+    * The maximum tile zoom level of the map. Defaults to 20.
+    * Increasing this will allow you to zoom further into the map but should
+    * only be used if you know what you are doing past zoom 20. The default
+    * map styles won't render anything useful past 20.
+    */
+  maxZoom: PropTypes.number,
+  /**
     * The Mapbox style the component should use. Can either be a string url
     * or a MapboxGL style Immutable.Map object.
     */
@@ -91,7 +98,7 @@ const PROP_TYPES = {
     * during dragging. Where the map is depends on where you first clicked on
     * the map.
     */
-  startDragLngLat: PropTypes.array,
+  startDragLngLat: PropTypes.object,
   /**
     * Called when a feature is hovered over. Uses Mapbox's
     * queryRenderedFeatures API to find features under the pointer:
@@ -185,7 +192,7 @@ const PROP_TYPES = {
 };
 
 const DEFAULT_PROPS = {
-  mapStyle: 'mapbox://styles/mapbox/light-v8',
+  mapStyle: 'mapbox://styles/mapbox/light-v9',
   onChangeViewport: null,
   mapboxApiAccessToken: config.DEFAULTS.MAPBOX_API_ACCESS_TOKEN,
   preserveDrawingBuffer: false,
@@ -194,7 +201,8 @@ const DEFAULT_PROPS = {
   bearing: 0,
   pitch: 0,
   altitude: 1.5,
-  clickRadius: 15
+  clickRadius: 15,
+  maxZoom: 20
 };
 
 @pureRender
@@ -236,6 +244,7 @@ export default class MapGL extends Component {
       container: this.refs.mapboxMap,
       center: [this.props.longitude, this.props.latitude],
       zoom: this.props.zoom,
+      maxZoom: this.props.maxZoom,
       pitch: this.props.pitch,
       bearing: this.props.bearing,
       style: mapStyle,
@@ -301,9 +310,8 @@ export default class MapGL extends Component {
 
   _updateStateFromProps(oldProps, newProps) {
     mapboxgl.accessToken = newProps.mapboxApiAccessToken;
-    const {startDragLngLat} = newProps;
     this.setState({
-      startDragLngLat: startDragLngLat && startDragLngLat.slice()
+      startDragLngLat: newProps.startDragLngLat
     });
   }
 
@@ -539,10 +547,10 @@ export default class MapGL extends Component {
 
   @autobind _onMouseDown({pos}) {
     const {transform} = this._map;
-    const lngLat = unprojectFromTransform(transform, new Point(...pos));
+    const {lng, lat} = unprojectFromTransform(transform, new Point(...pos));
     this._callOnChangeViewport(transform, {
       isDragging: true,
-      startDragLngLat: [lngLat.lng, lngLat.lat],
+      startDragLngLat: {lng, lat},
       startBearing: transform.bearing,
       startPitch: transform.pitch
     });


### PR DESCRIPTION
This includes modifying the `startDragLngLat` from an array to an object, which might be a breaking change if people have been using this variable other than just passing it back into the map instance. @ibgreen what do you think we should do here?

For context, it was changed to an object because the `transform` utilities in the new mapbox version expects an object that looks like `{lng, lat}` and not an array anymore.