### PR TITLE
run flow remove types in javascript through postinstall.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "d3-scale": "^1.0.3",
     "d3-selection": "^1.0.2",
     "flow-remove-types": "^1.1.2",
+    "glob": "^7.1.1",
     "global": "^4.3.0",
     "mapbox-gl": "0.32.1",
     "pure-render-decorator": "^1.1.0",
@@ -67,12 +68,13 @@
     "precommit": "npm run lint -s",
     "prepush": "npm run lint -s",
     "prepublish": "npm run build",
-    "postinstall": "(flow-remove-types node_modules/mapbox-gl/js/**/*.js --out-dir . >/dev/null 2>&1) || (flow-remove-types ../mapbox-gl/js/**/*.js --out-dir . >/dev/null 2>&1) || true",
+    "postinstall": "node postinstall.js",
     "profile-disc": "browserify src/index.js --full-paths -t babelify | discify --open"
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "postinstall.js"
   ],
   "peerDependencies": {
     "immutable": "^3.7.6",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,34 @@
+/* eslint-disable */
+/**
+ * NOTE: This is meant to be temporary, until we can figure out a good solution
+ * for living in a mapbox-gl flow types world.
+ */
+var flowRemoveTypes = require('flow-remove-types');
+var fs = require('fs');
+var glob = require('glob');
+
+var MAPBOX_PATHS = [
+  '../mapbox-gl',
+  'node_modules/mapbox-gl'
+];
+
+function processPathAccess(path, err) {
+  // Bail if path access errored out. This means the path does not exist
+  if (err) {
+    return;
+  }
+  // Otherwise run flow remove types on files
+  glob(path + '/js/**/*.js', {}, function globCallback(err, fileNames) {
+    for (var i = 0; i < fileNames.length; i++) {
+      var fileName = fileNames[i];
+      // This doesn't have to be synchronous(?)
+      var fileInput = fs.readFileSync(fileName, 'utf8');
+      fs.writeFileSync(fileName, flowRemoveTypes(fileInput).toString());
+    }
+  });
+}
+
+MAPBOX_PATHS.forEach(function eachPath(path) {
+  fs.access(path, processPathAccess.bind(null, path));
+});
+/* eslint-enable */


### PR DESCRIPTION
Works well for both development + installed in another code base, and fast. I'm installing virtualbox now to test on windows.

Vanilla Javascript because vanilla is always the best flavor.