### PR TITLE
Consistent handling of map children

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -90,14 +90,14 @@ export default class InteractiveMap extends PureComponent {
           ref: map => {
             this._map = map;
           },
-          children: mapVisible && this.props.children
+          children: null
         })),
         createElement('div', {
-          key: 'map-children',
-          style: {position: 'absolute', left: 0, top: 0}
-        },
-          !mapVisible && this.props.children
-        )
+          key: 'map-overlays',
+          className: 'overlays',
+          style: {position: 'absolute', left: 0, top: 0},
+          children: this.props.children
+        })
       ])
     );
   }

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -94,6 +94,7 @@ export default class InteractiveMap extends PureComponent {
         })),
         createElement('div', {
           key: 'map-overlays',
+          // Same as static map's overlay container
           className: 'overlays',
           style: {position: 'absolute', left: 0, top: 0},
           children: this.props.children

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -472,6 +472,7 @@ export default class StaticMap extends PureComponent {
           }),
           createElement('div', {
             key: 'map-overlays',
+            // Same as interactive map's overlay container
             className: 'overlays',
             style: overlayContainerStyle,
             children: this.props.children


### PR DESCRIPTION
- Assign the same class name to children container between InteractiveMap and StaticMap
- Always render map children under the same node (avoid unmount/mount when the map is shown/hidden)