### PR TITLE
bump mapbox-gl to 0.27 to prevent its devDependencies from being installed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "d3-scale": "^1.0.3",
     "d3-selection": "^1.0.2",
     "global": "^4.3.0",
-    "mapbox-gl": "0.26.0",
+    "mapbox-gl": "0.27.0",
     "pure-render-decorator": "^1.1.0",
     "svg-transform": "0.0.3",
     "viewport-mercator-project": "^2.0.1"


### PR DESCRIPTION
mapbox-gl contained a shrinkwrap with all of its devDependencies listed:
https://github.com/mapbox/mapbox-gl-js/issues/3374