### PR TITLE
Remove pressKeytoRotate prop from MapControl

### DIFF
--- a/examples/custom-interactions/view.js
+++ b/examples/custom-interactions/view.js
@@ -120,7 +120,6 @@ export default class Example extends Component {
     return (
       <InteractiveMap
         { ...viewport }
-        pressKeyToRotate={false}
         maxPitch={85}
         onChangeViewport={ this._onChangeViewport }
         onClickFeatures={ this._onClickFeatures }

--- a/examples/main/app.js
+++ b/examples/main/app.js
@@ -43,7 +43,6 @@ export default class App extends Component {
     return (
       <div>
         <TiltExample {...common} width={this.state.width - 30}/>
-        <TiltExample {...common} width={this.state.width - 30} pressKeyToRotate={false}/>
         <RouteOverlayExample {...common}/>
         <ScatterplotOverlayExample {...common}/>
         <CustomOverlayExample {...common}/>

--- a/src/components/map-controls.js
+++ b/src/components/map-controls.js
@@ -50,19 +50,12 @@ const propTypes = Object.assign({}, MapState.propTypes, {
     * rendering while dragging.
     */
   isHovering: PropTypes.bool,
-  isDragging: PropTypes.bool,
-
-  /**
-    * True means key must be pressed to rotate instead of pan
-    * false to means key must be pressed to pan
-    */
-  pressKeyToRotate: PropTypes.bool
+  isDragging: PropTypes.bool
 });
 
 const defaultProps = {
   perspectiveEnabled: false,
-  onChangeViewport: null,
-  pressKeyToRotate: true
+  onChangeViewport: null
 };
 
 export default class MapControls extends PureComponent {
@@ -134,7 +127,7 @@ export default class MapControls extends PureComponent {
       return;
     }
 
-    if (this.props.pressKeyToRotate === modifier) {
+    if (modifier) {
       this._onMouseRotate({pos, startPos});
     } else {
       this._onMousePan({pos});


### PR DESCRIPTION
Make our default map control match the default interaction in Mapbox.

Related proposal: [221](https://github.com/uber/react-map-gl/issues/221)