### PR TITLE
Improve MapState class and tests

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -4,6 +4,7 @@ import autobind from '../utils/autobind';
 
 import StaticMap from './static-map';
 import MapControls from './map-controls';
+import MapState from '../utils/map-state';
 
 const propTypes = {
   displayConstraints: PropTypes.object.isRequired
@@ -58,7 +59,8 @@ export default class InteractiveMap extends PureComponent {
     return (
       createElement(MapControls, Object.assign({}, this.props, {
         key: 'map-controls',
-        style: {position: 'relative'}
+        style: {position: 'relative'},
+        mapState: new MapState(this.props)
       }), [
         createElement(StaticMap, Object.assign({}, this.props, {
           key: 'map-static',

--- a/src/components/map-controls.js
+++ b/src/components/map-controls.js
@@ -34,7 +34,7 @@ const PITCH_ACCEL = 1.2;
 const ZOOM_ACCEL = 0.01;
 
 const propTypes = {
-  mapState: PropTypes.instanceOf(MapState),
+  mapState: PropTypes.instanceOf(MapState).isRequired,
 
   /** Enables perspective control event handling */
   perspectiveEnabled: PropTypes.bool,

--- a/src/components/map-controls.js
+++ b/src/components/map-controls.js
@@ -33,7 +33,8 @@ const PITCH_MOUSE_THRESHOLD = 5;
 const PITCH_ACCEL = 1.2;
 const ZOOM_ACCEL = 0.01;
 
-const propTypes = Object.assign({}, MapState.propTypes, {
+const propTypes = {
+  mapState: PropTypes.instanceOf(MapState),
 
   /** Enables perspective control event handling */
   perspectiveEnabled: PropTypes.bool,
@@ -51,7 +52,7 @@ const propTypes = Object.assign({}, MapState.propTypes, {
     */
   isHovering: PropTypes.bool,
   isDragging: PropTypes.bool
-});
+};
 
 const defaultProps = {
   perspectiveEnabled: false,
@@ -118,8 +119,8 @@ export default class MapControls extends PureComponent {
   }
 
   _onMouseDown({pos}) {
-    const mapState = new MapState(this.props).panStart({pos}).rotateStart({pos});
-    this._updateViewport(mapState.props, {isDragging: true});
+    const newMapState = this.props.mapState.panStart({pos}).rotateStart({pos});
+    this._updateViewport(newMapState.getViewportProps(), {isDragging: true});
   }
 
   _onMouseDrag({pos, startPos, modifier}) {
@@ -135,8 +136,8 @@ export default class MapControls extends PureComponent {
   }
 
   _onMousePan({pos}) {
-    const mapState = new MapState(this.props).pan({pos});
-    this._updateViewport(mapState.props);
+    const newMapState = this.props.mapState.pan({pos});
+    this._updateViewport(newMapState.getViewportProps());
   }
 
   _onMouseRotate({pos, startPos}) {
@@ -162,13 +163,13 @@ export default class MapControls extends PureComponent {
       }
     }
 
-    const mapState = new MapState(this.props).rotate({xDeltaScale, yDeltaScale});
-    this._updateViewport(mapState.props);
+    const newMapState = this.props.mapState.rotate({xDeltaScale, yDeltaScale});
+    this._updateViewport(newMapState.getViewportProps());
   }
 
   _onMouseUp() {
-    const mapState = new MapState(this.props).panEnd().rotateEnd();
-    this._updateViewport(mapState.props, {isDragging: false});
+    const newMapState = this.props.mapState.panEnd().rotateEnd();
+    this._updateViewport(newMapState.getViewportProps(), {isDragging: false});
   }
 
   _onWheel({pos, delta}) {
@@ -177,13 +178,13 @@ export default class MapControls extends PureComponent {
       scale = 1 / scale;
     }
 
-    const mapState = new MapState(this.props).zoom({pos, startPos: pos, scale});
-    this._updateViewport(mapState.props, {isDragging: true});
+    const newMapState = this.props.mapState.zoom({pos, scale});
+    this._updateViewport(newMapState.getViewportProps(), {isDragging: true});
   }
 
   _onWheelEnd() {
-    const mapState = new MapState(this.props).zoomEnd();
-    this._updateViewport(mapState.props, {isDragging: false});
+    const newMapState = this.props.mapState.zoomEnd();
+    this._updateViewport(newMapState.getViewportProps(), {isDragging: false});
   }
 
   render() {

--- a/src/components/map-controls.js
+++ b/src/components/map-controls.js
@@ -109,9 +109,17 @@ export default class MapControls extends PureComponent {
     return config.CURSOR.GRAB;
   }
 
-  _updateViewport(...opts) {
+  _updateViewport(mapState, extraState = {}) {
+    if (!this.props.onChangeViewport) {
+      return false;
+    }
+
     const {isDragging} = this.props;
-    return this.props.onChangeViewport(Object.assign({isDragging}, ...opts));
+    return this.props.onChangeViewport(Object.assign(
+      {isDragging},
+      mapState.getViewportProps(),
+      ...extraState
+    ));
   }
 
   _onTouchRotate(opts) {
@@ -120,7 +128,7 @@ export default class MapControls extends PureComponent {
 
   _onMouseDown({pos}) {
     const newMapState = this.props.mapState.panStart({pos}).rotateStart({pos});
-    this._updateViewport(newMapState.getViewportProps(), {isDragging: true});
+    this._updateViewport(newMapState, {isDragging: true});
   }
 
   _onMouseDrag({pos, startPos, modifier}) {
@@ -137,7 +145,7 @@ export default class MapControls extends PureComponent {
 
   _onMousePan({pos}) {
     const newMapState = this.props.mapState.pan({pos});
-    this._updateViewport(newMapState.getViewportProps());
+    this._updateViewport(newMapState);
   }
 
   _onMouseRotate({pos, startPos}) {
@@ -164,12 +172,12 @@ export default class MapControls extends PureComponent {
     }
 
     const newMapState = this.props.mapState.rotate({xDeltaScale, yDeltaScale});
-    this._updateViewport(newMapState.getViewportProps());
+    this._updateViewport(newMapState);
   }
 
   _onMouseUp() {
     const newMapState = this.props.mapState.panEnd().rotateEnd();
-    this._updateViewport(newMapState.getViewportProps(), {isDragging: false});
+    this._updateViewport(newMapState, {isDragging: false});
   }
 
   _onWheel({pos, delta}) {
@@ -179,12 +187,12 @@ export default class MapControls extends PureComponent {
     }
 
     const newMapState = this.props.mapState.zoom({pos, scale});
-    this._updateViewport(newMapState.getViewportProps(), {isDragging: true});
+    this._updateViewport(newMapState, {isDragging: true});
   }
 
   _onWheelEnd() {
     const newMapState = this.props.mapState.zoomEnd();
-    this._updateViewport(newMapState.getViewportProps(), {isDragging: false});
+    this._updateViewport(newMapState, {isDragging: false});
   }
 
   render() {

--- a/src/components/map-controls.js
+++ b/src/components/map-controls.js
@@ -118,7 +118,7 @@ export default class MapControls extends PureComponent {
     return this.props.onChangeViewport(Object.assign(
       {isDragging},
       mapState.getViewportProps(),
-      ...extraState
+      extraState
     ));
   }
 

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -1,149 +1,296 @@
-import PropTypes from 'prop-types';
 import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 import assert from 'assert';
-
-// MAPBOX LIMITS
-const MAX_PITCH = 60;
-const MAX_ZOOM = 20;
 
 function mod(value, divisor) {
   const modulus = value % divisor;
   return modulus < 0 ? divisor + modulus : modulus;
 }
 
-const propTypes = {
-  /** The width of the map */
-  width: PropTypes.number.isRequired,
-  /** The height of the map */
-  height: PropTypes.number.isRequired,
-  /** The latitude of the center of the map. */
-  latitude: PropTypes.number.isRequired,
-  /** The longitude of the center of the map. */
-  longitude: PropTypes.number.isRequired,
-  /** The tile zoom level of the map. */
-  zoom: PropTypes.number.isRequired,
-  /** Specify the bearing of the viewport */
-  bearing: PropTypes.number,
-  /** Specify the pitch of the viewport */
-  pitch: PropTypes.number,
-  /**
-    * Specify the altitude of the viewport camera
-    * Unit: map heights, default 1.5
-    * Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-    */
-  altitude: PropTypes.number,
+const defaultProps = {
+  pitch: 0,
+  bearing: 0,
+  altitude: 1.5,
 
-  /** Constraints */
-  maxZoom: PropTypes.number,
-  minZoom: PropTypes.number,
-  maxPitch: PropTypes.number,
-  minPitch: PropTypes.number,
-
-  /**
-    * Required to calculate the mouse projection during panning.
-    * The point on map being grabbed when the operation first started.
-    */
-  startPanLngLat: PropTypes.arrayOf(PropTypes.number),
-  /**
-    * Required to calculate the mouse projection during zooming.
-    * Center of the zoom when the operation first started.
-    */
-  startZoomLngLat: PropTypes.arrayOf(PropTypes.number),
-  /** Bearing when current perspective rotate operation started */
-  startBearing: PropTypes.number,
-  /** Pitch when current perspective rotate operation started */
-  startPitch: PropTypes.number,
-  /** Zoom when current zoom operation started */
-  startZoom: PropTypes.number
+  // MAPBOX LIMITS
+  maxZoom: 20,
+  minZoom: 0,
+  maxPitch: 60,
+  minPitch: 0
 };
 
 export default class MapState {
 
   constructor({
     /** Mapbox viewport properties */
+    /** The width of the viewport */
     width,
+    /** The height of the viewport */
     height,
+    /** The latitude at the center of the viewport */
     latitude,
+    /** The longitude at the center of the viewport */
     longitude,
+    /** The tile zoom level of the map. */
     zoom,
-    bearing = 0,
-    pitch = 0,
-    altitude = 1.5,
+    /** The bearing of the viewport in degrees */
+    bearing,
+    /** The pitch of the viewport in degrees */
+    pitch,
+    /**
+    * Specify the altitude of the viewport camera
+    * Unit: map heights, default 1.5
+    * Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
+    */
+    altitude,
 
     /** Viewport constraints */
-    maxZoom = MAX_ZOOM,
-    minZoom = 0,
-    maxPitch = MAX_PITCH,
-    minPitch = 0,
+    maxZoom,
+    minZoom,
+    maxPitch,
+    minPitch,
 
-    /** Interaction states */
+    /** Interaction states, required to calculate change during transform */
+    /* The point on map being grabbed when the operation first started */
     startPanLngLat,
+    /* Center of the zoom when the operation first started */
     startZoomLngLat,
+    /** Bearing when current perspective rotate operation started */
     startBearing,
+    /** Pitch when current perspective rotate operation started */
     startPitch,
+    /** Zoom when current zoom operation started */
     startZoom
   } = {}) {
-    this.props = {
+    assert(Number.isFinite(width), '`width` must be supplied');
+    assert(Number.isFinite(height), '`height` must be supplied');
+    assert(Number.isFinite(longitude), '`longitude` must be supplied');
+    assert(Number.isFinite(latitude), '`latitude` must be supplied');
+    assert(Number.isFinite(zoom), '`zoom` must be supplied');
+
+    this._props = this._applyConstraints({
       width,
       height,
       latitude,
       longitude,
       zoom,
-      bearing,
-      pitch,
-      altitude,
-      maxZoom,
-      minZoom,
-      maxPitch,
-      minPitch,
+      bearing: Number.isFinite(bearing) ? bearing : defaultProps.bearing,
+      pitch: Number.isFinite(pitch) ? pitch : defaultProps.pitch,
+      altitude: Number.isFinite(altitude) ? altitude : defaultProps.altitude,
+      maxZoom: Number.isFinite(maxZoom) ? maxZoom : defaultProps.maxZoom,
+      minZoom: Number.isFinite(minZoom) ? minZoom : defaultProps.minZoom,
+      maxPitch: Number.isFinite(maxPitch) ? maxPitch : defaultProps.maxPitch,
+      minPitch: Number.isFinite(minPitch) ? minPitch : defaultProps.minPitch,
       startPanLngLat,
+      startZoomLngLat,
+      startBearing,
+      startPitch,
+      startZoom
+    });
+  }
+
+  /* Public API */
+
+  getViewportProps() {
+    return this._props;
+  }
+
+  /**
+   * Start panning
+   * @param {[Number, Number]} pos - position on screen where the pointer grabs
+   */
+  panStart({pos}) {
+    return this._getUpdatedMapState({
+      startPanLngLat: this._unproject(pos)
+    });
+  }
+
+  /**
+   * Pan
+   * @param {[Number, Number]} pos - position on screen where the pointer is
+   * @param {[Number, Number], optional} startPos - where the pointer grabbed at
+   *   the start of the operation. Must be supplied of `panStart()` was not called
+   */
+  pan({pos, startPos}) {
+    const startPanLngLat = this._props.startPanLngLat || this._unproject(startPos);
+
+    // take the start lnglat and put it where the mouse is down.
+    assert(startPanLngLat, '`startPanLngLat` prop is required ' +
+      'for mouse pan behavior to calculate where to position the map.');
+
+    const [longitude, latitude] = this._calculateNewLngLat({startPanLngLat, pos});
+
+    return this._getUpdatedMapState({
+      longitude,
+      latitude
+    });
+  }
+
+  /**
+   * End panning
+   * Must call if `panStart()` was called
+   */
+  panEnd() {
+    return this._getUpdatedMapState({
+      startPanLngLat: null
+    });
+  }
+
+  /**
+   * Start rotating
+   * @param {[Number, Number]} pos - position on screen where the center is
+   */
+  rotateStart({pos}) {
+    return this._getUpdatedMapState({
+      startBearing: this._props.bearing,
+      startPitch: this._props.pitch
+    });
+  }
+
+  /**
+   * Rotate
+   * @param {Number} xDeltaScale - a number between [-1, 1] specifying the
+   *   change to bearing.
+   * @param {Number} yDeltaScale - a number between [-1, 1] specifying the
+   *   change to pitch. -1 sets to minPitch and 1 sets to maxPitch.
+   */
+  rotate({xDeltaScale, yDeltaScale}) {
+    assert(xDeltaScale >= -1 && xDeltaScale <= 1,
+      '`xDeltaScale` must be a number between [-1, 1]');
+    assert(yDeltaScale >= -1 && yDeltaScale <= 1,
+      '`yDeltaScale` must be a number between [-1, 1]');
+
+    let {startBearing, startPitch} = this._props;
+
+    if (!Number.isFinite(startBearing)) {
+      startBearing = this._props.bearing;
+    }
+    if (!Number.isFinite(startPitch)) {
+      startPitch = this._props.pitch;
+    }
+
+    const {pitch, bearing} = this._calculateNewPitchAndBearing({
+      xDeltaScale,
+      yDeltaScale,
       startBearing,
       startPitch
-    };
+    });
+
+    return this._getUpdatedMapState({
+      bearing,
+      pitch
+    });
   }
 
-  _updateViewport(opts) {
-    // Update props
-    Object.assign(this.props, opts);
-    this._applyConstraints();
-    return this;
+  /**
+   * End rotating
+   * Must call if `rotateStart()` was called
+   */
+  rotateEnd() {
+    return this._getUpdatedMapState({
+      startBearing: null,
+      startPitch: null
+    });
   }
 
-  // Apply any constraints (mathematical or defined by props) to viewport params
-  _applyConstraints() {
-    const viewport = this.props;
+  /**
+   * Start zooming
+   * @param {[Number, Number]} pos - position on screen where the center is
+   */
+  zoomStart({pos}) {
+    return this._getUpdatedMapState({
+      startZoomLngLat: this._unproject(pos),
+      startZoom: this._props.zoom
+    });
+  }
+
+  /**
+   * Zoom
+   * @param {[Number, Number]} pos - position on screen where the current center is
+   * @param {[Number, Number]} startPos - the center position at
+   *   the start of the operation. Must be supplied of `zoomStart()` was not called
+   * @param {Number} scale - a number between [0, 1] specifying the accumulated
+   *   relative scale.
+   */
+  zoom({pos, startPos, scale}) {
+    assert(scale > 0, '`scale` must be a positive number');
+
+    // Make sure we zoom around the current mouse position rather than map center
+    const startZoomLngLat = this._props.startZoomLngLat ||
+      this._unproject(startPos) || this._unproject(pos);
+    let {startZoom} = this._props;
+
+    if (!Number.isFinite(startZoom)) {
+      startZoom = this._props.zoom;
+    }
+
+    // take the start lnglat and put it where the mouse is down.
+    assert(startZoomLngLat, '`startZoomLngLat` prop is required ' +
+      'for zoom behavior to calculate where to position the map.');
+
+    const zoom = this._calculateNewZoom({scale, startZoom});
+
+    const zoomedViewport = new PerspectiveMercatorViewport(Object.assign({}, this._props, {zoom}));
+    const [longitude, latitude] = zoomedViewport.getLocationAtPoint({lngLat: startZoomLngLat, pos});
+
+    return this._getUpdatedMapState({
+      zoom,
+      longitude,
+      latitude
+    });
+  }
+
+  /**
+   * End zooming
+   * Must call if `zoomStart()` was called
+   */
+  zoomEnd() {
+    return this._getUpdatedMapState({
+      startZoomLngLat: null,
+      startZoom: null
+    });
+  }
+
+  /* Private methods */
+
+  _getUpdatedMapState(newProps) {
+    // Update _props
+    return new MapState(Object.assign({}, this._props, newProps));
+  }
+
+  // Apply any constraints (mathematical or defined by _props) to map state
+  _applyConstraints(props) {
     // Normalize degrees
-    viewport.longitude = mod(viewport.longitude + 180, 360) - 180;
-    viewport.bearing = mod(viewport.bearing + 180, 360) - 180;
+    props.longitude = mod(props.longitude + 180, 360) - 180;
+    props.bearing = mod(props.bearing + 180, 360) - 180;
 
     // Ensure zoom is within specified range
-    const {maxZoom, minZoom} = this.props;
-    viewport.zoom = viewport.zoom > maxZoom ? maxZoom : viewport.zoom;
-    viewport.zoom = viewport.zoom < minZoom ? minZoom : viewport.zoom;
+    const {maxZoom, minZoom, zoom} = props;
+    props.zoom = zoom > maxZoom ? maxZoom : zoom;
+    props.zoom = zoom < minZoom ? minZoom : zoom;
 
     // Ensure pitch is within specified range
-    const {maxPitch, minPitch} = this.props;
+    const {maxPitch, minPitch, pitch} = props;
 
-    viewport.pitch = viewport.pitch > maxPitch ? maxPitch : viewport.pitch;
-    viewport.pitch = viewport.pitch < minPitch ? minPitch : viewport.pitch;
+    props.pitch = pitch > maxPitch ? maxPitch : pitch;
+    props.pitch = pitch < minPitch ? minPitch : pitch;
 
-    return viewport;
+    return props;
   }
 
   _unproject(pos) {
-    const viewport = new PerspectiveMercatorViewport(this.props);
+    const viewport = new PerspectiveMercatorViewport(this._props);
     return pos && viewport.unproject(pos, {topLeft: false});
   }
 
   // Calculate a new lnglat based on pixel dragging position
   _calculateNewLngLat({startPanLngLat, pos}) {
-    const viewport = new PerspectiveMercatorViewport(this.props);
+    const viewport = new PerspectiveMercatorViewport(this._props);
     return viewport.getLocationAtPoint({lngLat: startPanLngLat, pos});
   }
 
   // Calculates new zoom
   _calculateNewZoom({scale, startZoom}) {
-    const {maxZoom, minZoom} = this.props;
+    const {maxZoom, minZoom} = this._props;
     let zoom = startZoom + Math.log2(scale);
     zoom = zoom > maxZoom ? maxZoom : zoom;
     zoom = zoom < minZoom ? minZoom : zoom;
@@ -152,7 +299,7 @@ export default class MapState {
 
   // Calculates a new pitch and bearing from a position (coming from an event)
   _calculateNewPitchAndBearing({xDeltaScale, yDeltaScale, startBearing, startPitch}) {
-    const {minPitch, maxPitch} = this.props;
+    const {minPitch, maxPitch} = this._props;
 
     const bearing = startBearing + 180 * xDeltaScale;
     let pitch = startPitch;
@@ -170,163 +317,4 @@ export default class MapState {
     };
   }
 
-  /* Public API */
-
-  /**
-   * Start panning
-   * @param {[Number, Number]} pos - position on screen where the pointer grabs
-   */
-  panStart({pos}) {
-    return this._updateViewport({
-      startPanLngLat: this._unproject(pos)
-    });
-  }
-
-  /**
-   * Pan
-   * @param {[Number, Number]} pos - position on screen where the pointer is
-   * @param {[Number, Number], optional} startPos - where the pointer grabbed at
-   *   the start of the operation. Must be supplied of `panStart()` was not called
-   */
-  pan({pos, startPos}) {
-    const startPanLngLat = this.props.startPanLngLat || this._unproject(startPos);
-
-    // take the start lnglat and put it where the mouse is down.
-    assert(startPanLngLat, '`startPanLngLat` prop is required ' +
-      'for mouse pan behavior to calculate where to position the map.');
-
-    const [longitude, latitude] = this._calculateNewLngLat({startPanLngLat, pos});
-
-    return this._updateViewport({
-      longitude,
-      latitude
-    });
-  }
-
-  /**
-   * End panning
-   * Must call if `panStart()` was called
-   */
-  panEnd() {
-    return this._updateViewport({
-      startPanLngLat: null
-    });
-  }
-
-  /**
-   * Start rotating
-   * @param {[Number, Number]} pos - position on screen where the center is
-   */
-  rotateStart({pos}) {
-    return this._updateViewport({
-      startBearing: this.props.bearing,
-      startPitch: this.props.pitch
-    });
-  }
-
-  /**
-   * Rotate
-   * @param {Number} xDeltaScale - a number between [-1, 1] specifying the
-   *   change to bearing.
-   * @param {Number} yDeltaScale - a number between [-1, 1] specifying the
-   *   change to pitch. -1 sets to minPitch and 1 sets to maxPitch.
-   */
-  rotate({xDeltaScale, yDeltaScale}) {
-    assert(xDeltaScale >= -1 && xDeltaScale <= 1,
-      '`xDeltaScale` must be a number between [-1, 1]');
-    assert(yDeltaScale >= -1 && yDeltaScale <= 1,
-      '`yDeltaScale` must be a number between [-1, 1]');
-
-    let {startBearing, startPitch} = this.props;
-
-    if (!Number.isFinite(startBearing)) {
-      startBearing = this.props.bearing;
-    }
-    if (!Number.isFinite(startPitch)) {
-      startPitch = this.props.pitch;
-    }
-
-    const {pitch, bearing} = this._calculateNewPitchAndBearing({
-      xDeltaScale,
-      yDeltaScale,
-      startBearing,
-      startPitch
-    });
-
-    return this._updateViewport({
-      bearing,
-      pitch
-    });
-  }
-
-  /**
-   * End rotating
-   * Must call if `rotateStart()` was called
-   */
-  rotateEnd() {
-    return this._updateViewport({
-      startBearing: null,
-      startPitch: null
-    });
-  }
-
-  /**
-   * Start zooming
-   * @param {[Number, Number]} pos - position on screen where the center is
-   */
-  zoomStart({pos}) {
-    return this._updateViewport({
-      startZoomLngLat: this._unproject(pos),
-      startZoom: this.props.zoom
-    });
-  }
-
-  /**
-   * Zoom
-   * @param {[Number, Number]} pos - position on screen where the current center is
-   * @param {[Number, Number]} startPos - the center position at
-   *   the start of the operation. Must be supplied of `zoomStart()` was not called
-   * @param {Number} scale - a number between [0, 1] specifying the accumulated
-   *   relative scale.
-   */
-  zoom({pos, startPos, scale}) {
-    assert(scale > 0, '`scale` must be a positive number');
-
-    // Make sure we zoom around the current mouse position rather than map center
-    const startZoomLngLat = this.props.startZoomLngLat || this._unproject(startPos);
-    let {startZoom} = this.props;
-
-    if (!Number.isFinite(startZoom)) {
-      startZoom = this.props.zoom;
-    }
-
-    // take the start lnglat and put it where the mouse is down.
-    assert(startZoomLngLat, '`startZoomLngLat` prop is required ' +
-      'for zoom behavior to calculate where to position the map.');
-
-    const zoom = this._calculateNewZoom({scale, startZoom});
-
-    const zoomedViewport = new PerspectiveMercatorViewport(Object.assign({}, this.props, {zoom}));
-    const [longitude, latitude] = zoomedViewport.getLocationAtPoint({lngLat: startZoomLngLat, pos});
-
-    return this._updateViewport({
-      zoom,
-      longitude,
-      latitude
-    });
-  }
-
-  /**
-   * End zooming
-   * Must call if `zoomStart()` was called
-   */
-  zoomEnd() {
-    return this._updateViewport({
-      startZoomLngLat: null,
-      startZoom: null
-    });
-  }
-
 }
-
-MapState.propTypes = propTypes;

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -6,17 +6,21 @@ function mod(value, divisor) {
   return modulus < 0 ? divisor + modulus : modulus;
 }
 
+// MAPBOX LIMITS
+const MAX_PITCH = 60;
+const MAX_ZOOM = 20;
+
 const defaultState = {
   pitch: 0,
   bearing: 0,
   altitude: 1.5,
-
-  // MAPBOX LIMITS
-  maxZoom: 20,
+  maxZoom: MAX_ZOOM,
   minZoom: 0,
-  maxPitch: 60,
+  maxPitch: MAX_PITCH,
   minPitch: 0
 };
+
+const ensureFinite = (value, fallbackValue) => Number.isFinite(value) ? value : fallbackValue;
 
 export default class MapState {
 
@@ -73,13 +77,13 @@ export default class MapState {
       latitude,
       longitude,
       zoom,
-      bearing: Number.isFinite(bearing) ? bearing : defaultState.bearing,
-      pitch: Number.isFinite(pitch) ? pitch : defaultState.pitch,
-      altitude: Number.isFinite(altitude) ? altitude : defaultState.altitude,
-      maxZoom: Number.isFinite(maxZoom) ? maxZoom : defaultState.maxZoom,
-      minZoom: Number.isFinite(minZoom) ? minZoom : defaultState.minZoom,
-      maxPitch: Number.isFinite(maxPitch) ? maxPitch : defaultState.maxPitch,
-      minPitch: Number.isFinite(minPitch) ? minPitch : defaultState.minPitch,
+      bearing: ensureFinite(bearing, defaultState.bearing),
+      pitch: ensureFinite(pitch, defaultState.pitch),
+      altitude: ensureFinite(altitude, defaultState.altitude),
+      maxZoom: ensureFinite(maxZoom, defaultState.maxZoom),
+      minZoom: ensureFinite(minZoom, defaultState.minZoom),
+      maxPitch: ensureFinite(maxPitch, defaultState.maxPitch),
+      minPitch: ensureFinite(minPitch, defaultState.minPitch),
       startPanLngLat,
       startZoomLngLat,
       startBearing,

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -1,11 +1,6 @@
 import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 import assert from 'assert';
 
-function mod(value, divisor) {
-  const modulus = value % divisor;
-  return modulus < 0 ? divisor + modulus : modulus;
-}
-
 // MAPBOX LIMITS
 const MAX_PITCH = 60;
 const MAX_ZOOM = 20;
@@ -20,7 +15,15 @@ const defaultState = {
   minPitch: 0
 };
 
-const ensureFinite = (value, fallbackValue) => Number.isFinite(value) ? value : fallbackValue;
+/* Utils */
+function mod(value, divisor) {
+  const modulus = value % divisor;
+  return modulus < 0 ? divisor + modulus : modulus;
+}
+
+function ensureFinite(value, fallbackValue) {
+  return Number.isFinite(value) ? value : fallbackValue;
+}
 
 export default class MapState {
 

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -6,7 +6,7 @@ function mod(value, divisor) {
   return modulus < 0 ? divisor + modulus : modulus;
 }
 
-const defaultProps = {
+const defaultState = {
   pitch: 0,
   bearing: 0,
   altitude: 1.5,
@@ -73,13 +73,13 @@ export default class MapState {
       latitude,
       longitude,
       zoom,
-      bearing: Number.isFinite(bearing) ? bearing : defaultProps.bearing,
-      pitch: Number.isFinite(pitch) ? pitch : defaultProps.pitch,
-      altitude: Number.isFinite(altitude) ? altitude : defaultProps.altitude,
-      maxZoom: Number.isFinite(maxZoom) ? maxZoom : defaultProps.maxZoom,
-      minZoom: Number.isFinite(minZoom) ? minZoom : defaultProps.minZoom,
-      maxPitch: Number.isFinite(maxPitch) ? maxPitch : defaultProps.maxPitch,
-      minPitch: Number.isFinite(minPitch) ? minPitch : defaultProps.minPitch,
+      bearing: Number.isFinite(bearing) ? bearing : defaultState.bearing,
+      pitch: Number.isFinite(pitch) ? pitch : defaultState.pitch,
+      altitude: Number.isFinite(altitude) ? altitude : defaultState.altitude,
+      maxZoom: Number.isFinite(maxZoom) ? maxZoom : defaultState.maxZoom,
+      minZoom: Number.isFinite(minZoom) ? minZoom : defaultState.minZoom,
+      maxPitch: Number.isFinite(maxPitch) ? maxPitch : defaultState.maxPitch,
+      minPitch: Number.isFinite(minPitch) ? minPitch : defaultState.minPitch,
       startPanLngLat,
       startZoomLngLat,
       startBearing,


### PR DESCRIPTION
Addressing comments on [PR#212](https://github.com/uber/react-map-gl/pull/212)
- `MapControl` takes a `MapState` instance instead of list of viewport props
- Always return a new `MapState` object after transform
- Better naming of properties and methods
- Code consistency and error checking
- Tests cover more use cases