### PR TITLE
Add marker component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 3.0.0 (Alpha)
 
+[TBD]
+- Add Marker control
+
 ### Version 3.0.0-alpha.8 - Fix server side rendering of InteractiveMap
 
 ### Version 3.0.0-alpha.7 - Bug fixes

--- a/docs/controls/Marker.md
+++ b/docs/controls/Marker.md
@@ -1,0 +1,31 @@
+# Marker Control
+
+This is a React equivalent of Mapbox's [Marker Control](https://www.mapbox.com/mapbox-gl-js/api/#marker):
+
+```js
+import ReactMap, {Marker} from 'react-map-gl';
+
+export default MyMap = () => {
+  return (
+    <ReactMap latitude={-122.41} longitude={37.78} zoom={8}>
+      <Marker latitude={-122.41} longitude={37.78} offsetLeft={-20} offsetTop={-10}>
+        <div>You are here</div>
+      </Marker>
+    </ReactMap>
+  );
+}
+```
+
+## Properties
+
+##### `latitude` (Number)
+Latitude of the marker.
+
+##### `longitude` (Number)
+Longitude of the marker.
+
+##### `offsetLeft` (Number, optional)
+Offset of the marker from the left in pixels, negative number indicates left.
+
+##### `offsetTop` (Number, optional)
+Offset of the marker from the top in pixels, negative number indicates up.

--- a/examples/custom-interactions/view.js
+++ b/examples/custom-interactions/view.js
@@ -38,15 +38,12 @@ const locations = Immutable.fromJS(new Array(4000).fill(0).map(() => [
 ]));
 
 const MARKER_STYLE = {
-  fill: '#d00',
-  transform: 'translate(-50%,-100%)',
   cursor: 'pointer'
 };
 
-const MARKER_ICON = `M45.4,39.7C45.4,39.7,45.4,39.7,45.4,39.7c2.8-4.1,4.4-8.9,4.4-14.2
- C49.9,11.7,38.7,0.6,25,0.6S0.1,11.7,0.1,25.4c0,5,1.5,9.6,4,13.4c0.1,0.2,0.3,0.5,0.5,
- 0.8c0.1,0.1,0.2,0.3,0.3,0.4 c0.6,0.8,1.1,1.5,1.8,2.2C13.1,49.8,25,61,25,61s11.9-11.2,
- 18.3-18.7c0.6-0.7,1.2-1.4,1.8-2.2C45.2,39.9,45.3,39.8,45.4,39.7z`;
+const MARKER_ICON = `M18.2,15.7L18.2,15.7c1.1-1.6,1.8-3.6,1.8-5.7c0-5.6-4.5-10-10-10S0,4.5,0,10c0,2,0.6,3.9,1.6,5.4c0,0.1,0.1,0.2,0.2,0.3
+  c0,0,0.1,0.1,0.1,0.2c0.2,0.3,0.4,0.6,0.7,0.9c2.6,3.1,7.4,7.6,7.4,7.6s4.8-4.5,7.4-7.5c0.2-0.3,0.5-0.6,0.7-0.9
+  C18.1,15.8,18.2,15.8,18.2,15.7z`;
 
 function buildStyle({fill = 'red', stroke = 'blue'}) {
   return Immutable.fromJS({
@@ -124,8 +121,10 @@ export default class Example extends Component {
 
   _renderCityMarker(city, index) {
     return (
-      <Marker key={index} longitude={city.longitude} latitude={city.latitude}>
-        <svg width='20px' viewBox='0 0 50 61' style={MARKER_STYLE}>
+      <Marker key={index}
+        longitude={city.longitude} latitude={city.latitude}
+        offsetLeft={-10} offsetTop={-24}>
+        <svg width={20} viewBox='0 0 20 24' style={MARKER_STYLE}>
           <path fill='#d00' d={MARKER_ICON}/>
         </svg>
       </Marker>

--- a/examples/custom-interactions/view.js
+++ b/examples/custom-interactions/view.js
@@ -21,7 +21,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import autobind from 'react-autobind';
-import {InteractiveMap, ScatterplotOverlay} from 'react-map-gl';
+import {InteractiveMap, ScatterplotOverlay, Marker} from 'react-map-gl';
 import DeckGL, {ArcLayer} from 'deck.gl';
 import Immutable from 'immutable';
 /* global window */
@@ -36,6 +36,17 @@ const locations = Immutable.fromJS(new Array(4000).fill(0).map(() => [
   location.longitude + Math.random() * 0.01,
   location.latitude + Math.random() * 0.01
 ]));
+
+const MARKER_STYLE = {
+  fill: '#d00',
+  transform: 'translate(-50%,-100%)',
+  cursor: 'pointer'
+};
+
+const MARKER_ICON = `M45.4,39.7C45.4,39.7,45.4,39.7,45.4,39.7c2.8-4.1,4.4-8.9,4.4-14.2
+ C49.9,11.7,38.7,0.6,25,0.6S0.1,11.7,0.1,25.4c0,5,1.5,9.6,4,13.4c0.1,0.2,0.3,0.5,0.5,
+ 0.8c0.1,0.1,0.2,0.3,0.3,0.4 c0.6,0.8,1.1,1.5,1.8,2.2C13.1,49.8,25,61,25,61s11.9-11.2,
+ 18.3-18.7c0.6-0.7,1.2-1.4,1.8-2.2C45.2,39.9,45.3,39.8,45.4,39.7z`;
 
 function buildStyle({fill = 'red', stroke = 'blue'}) {
   return Immutable.fromJS({
@@ -111,6 +122,16 @@ export default class Example extends Component {
     window.console.log(features);
   }
 
+  _renderCityMarker(city, index) {
+    return (
+      <Marker key={index} longitude={city.longitude} latitude={city.latitude}>
+        <svg width='20px' viewBox='0 0 50 61' style={MARKER_STYLE}>
+          <path fill='#d00' d={MARKER_ICON}/>
+        </svg>
+      </Marker>
+    );
+  }
+
   render() {
     const viewport = {
       // mapStyle: this.state.mapStyle,
@@ -143,6 +164,8 @@ export default class Example extends Component {
             getTargetColor: x => [0, 255, 0]
           })
         ]}/>
+
+        { CITIES.map(this._renderCityMarker) }
 
       </InteractiveMap>
     );

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "webworkify-webpack-dropin": "^1.1.9"
   },
   "peerDependencies": {
-    "react": "15.4.x"
+    "react": ">=15.4.x"
   },
   "engines": {
     "node": ">= 4",

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -5,16 +5,18 @@ import autobind from '../utils/autobind';
 import StaticMap from './static-map';
 import MapControls from './map-controls';
 import MapState from '../utils/map-state';
+import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 
-const propTypes = {
+const propTypes = Object.assign({}, StaticMap.propTypes, {
   displayConstraints: PropTypes.object.isRequired
-};
+});
 
-const defaultProps = {
+const defaultProps = Object.assign({}, StaticMap.defaultProps, {
   displayConstraints: {
+    maxZoom: 20,
     maxPitch: 60
   }
-};
+});
 
 export default class InteractiveMap extends PureComponent {
 
@@ -25,6 +27,12 @@ export default class InteractiveMap extends PureComponent {
   constructor(props) {
     super(props);
     autobind(this);
+  }
+
+  getChildContext() {
+    return {
+      viewport: new PerspectiveMercatorViewport(this.props)
+    };
   }
 
   // TODO - Remove once Viewport alternative is good enough
@@ -85,3 +93,5 @@ export default class InteractiveMap extends PureComponent {
 InteractiveMap.displayName = 'InteractiveMap';
 InteractiveMap.propTypes = propTypes;
 InteractiveMap.defaultProps = defaultProps;
+InteractiveMap.childContextTypes = StaticMap.childContextTypes;
+

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -61,8 +61,17 @@ export default class InteractiveMap extends PureComponent {
   }
 
   render() {
+    const {width, height} = this.props;
     const mapVisible = this.checkDisplayConstraints(this.props);
     const visibility = mapVisible ? 'visible' : 'hidden';
+    const overlayContainerStyle = {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      width,
+      height,
+      overflow: 'hidden'
+    };
 
     return (
       createElement(MapControls, Object.assign({}, this.props, {
@@ -72,7 +81,7 @@ export default class InteractiveMap extends PureComponent {
       }), [
         createElement(StaticMap, Object.assign({}, this.props, {
           key: 'map-static',
-          style: {visibility, position: 'absolute', left: 0, top: 0},
+          style: {visibility},
           ref: map => {
             this._map = map;
           },
@@ -82,7 +91,7 @@ export default class InteractiveMap extends PureComponent {
           key: 'map-overlays',
           // Same as static map's overlay container
           className: 'overlays',
-          style: {position: 'absolute', left: 0, top: 0},
+          style: overlayContainerStyle,
           children: this.props.children
         })
       ])

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -25,10 +25,16 @@ const propTypes = {
   // Longitude of the anchor point
   longitude: PropTypes.number.isRequired,
   // Latitude of the anchor point
-  latitude: PropTypes.number.isRequired
+  latitude: PropTypes.number.isRequired,
+  // Offset from the left
+  offsetLeft: PropTypes.number,
+  // Offset from the top
+  offsetTop: PropTypes.number
 };
 
 const defaultProps = {
+  offsetLeft: 0,
+  offsetTop: 0
 };
 
 const contextTypes = {
@@ -38,17 +44,18 @@ const contextTypes = {
 export default class Marker extends Component {
 
   render() {
-    const {longitude, latitude} = this.props;
+    const {longitude, latitude, offsetLeft, offsetTop} = this.props;
 
     const [x, y] = this.context.viewport.project([longitude, latitude]);
+    const containerStyle = {
+      position: 'absolute',
+      left: x + offsetLeft,
+      top: y + offsetTop
+    };
 
     return createElement('div', {
       className: 'map-control-marker',
-      style: {
-        position: 'absolute',
-        left: x,
-        top: y
-      },
+      style: containerStyle,
       children: this.props.children
     });
   }

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import {Component, createElement} from 'react';
+import PropTypes from 'prop-types';
+import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+
+const propTypes = {
+  // Longitude of the anchor point
+  longitude: PropTypes.number.isRequired,
+  // Latitude of the anchor point
+  latitude: PropTypes.number.isRequired
+};
+
+const defaultProps = {
+};
+
+const contextTypes = {
+  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
+};
+
+export default class Marker extends Component {
+
+  render() {
+    const {longitude, latitude} = this.props;
+
+    const [x, y] = this.context.viewport.project([longitude, latitude]);
+
+    return createElement('div', {
+      className: 'map-control-marker',
+      style: {
+        position: 'absolute',
+        left: x,
+        top: y
+      },
+      children: this.props.children
+    });
+  }
+
+}
+
+Marker.displayName = 'Marker';
+Marker.propTypes = propTypes;
+Marker.defaultProps = defaultProps;
+Marker.contextTypes = contextTypes;

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -28,6 +28,7 @@ import diffStyles from '../utils/diff-styles';
 import Immutable from 'immutable';
 
 import isBrowser from '../utils/is-browser';
+import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 
 let mapboxgl = null;
 let Point = null;
@@ -135,6 +136,10 @@ const defaultProps = {
   clickRadius: 15
 };
 
+const childContextTypes = {
+  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
+};
+
 export default class StaticMap extends PureComponent {
   static supported() {
     return mapboxgl && mapboxgl.supported();
@@ -159,6 +164,12 @@ export default class StaticMap extends PureComponent {
       this.componentDidUpdate = noop;
     }
     autobind(this);
+  }
+
+  getChildContext() {
+    return {
+      viewport: new PerspectiveMercatorViewport(this.props)
+    };
   }
 
   componentDidMount() {
@@ -486,3 +497,4 @@ export default class StaticMap extends PureComponent {
 StaticMap.displayName = 'StaticMap';
 StaticMap.propTypes = propTypes;
 StaticMap.defaultProps = defaultProps;
+StaticMap.childContextTypes = childContextTypes;

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -465,7 +465,14 @@ export default class StaticMap extends PureComponent {
     const {className, width, height, style} = this.props;
     const mapContainerStyle = Object.assign({}, style, {width, height, position: 'relative'});
     const mapStyle = Object.assign({}, style, {width, height});
-    const overlayContainerStyle = {position: 'absolute', left: 0, top: 0};
+    const overlayContainerStyle = {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      width,
+      height,
+      overflow: 'hidden'
+    };
 
     // Note: a static map still handles clicks and hover events
     return (

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@
 export {default as InteractiveMap} from './components/interactive-map';
 export {default as StaticMap} from './components/static-map';
 export {default as MapControls} from './components/map-controls';
+export {default as Marker} from './components/marker';
 
 export {default as default} from './components/interactive-map';
 export {default as MapGL} from './components/interactive-map';


### PR DESCRIPTION
A React equivalent to Mapbox's [Marker control](https://www.mapbox.com/mapbox-gl-js/api/#marker):
![screen shot 2017-05-03 at 3 34 45 pm](https://cloud.githubusercontent.com/assets/2059298/25684459/7aca589c-3016-11e7-9b14-0d246d5b6e6d.png)

Notes on using context:
- Pro: avoids destructing a long list of viewport props to pass down to all map overlay components
- Pro: the parent component that renders the Markers can be agnostic of the viewport
- Con: I believe context is still marked as an experimental feature of React
- Con: not supported by PureComponent. Though in this case it's not unreasonable to always re-render markers when the map updates, which is a very thin wrapper, and render the children of the markers as PureComponents.
