### PR TITLE
Attribution Control and Navigation Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Version 3.0.0 (Alpha)
 
-[TBD]
-- Add Marker control
+### Version 3.0.0-alpha.9
+- NEW: Marker component
+- NEW: Popup component
+- FIX: `attributeControl` prop
+- NEW: NavigationControl component
 
 ### Version 3.0.0-alpha.8 - Fix server side rendering of InteractiveMap
 

--- a/docs/controls/navigation-control.md
+++ b/docs/controls/navigation-control.md
@@ -1,0 +1,22 @@
+# Navigation Control
+
+This is a React equivalent of Mapbox's [NavigationControl](https://www.mapbox.com/mapbox-gl-js/api/#navigationcontrol):
+
+```js
+import ReactMap, {Marker} from 'react-map-gl';
+
+export default MyMap = ({viewport, updateViewport}) => {
+  return (
+    <ReactMap {...viewport} onChangeViewport={updateViewport}>
+      <div style={{position: 'absolute', right: 0}}>
+        <NavigationControl onChangeViewport={updateViewport} />
+      </div>
+    </ReactMap>
+  );
+}
+```
+
+## Properties
+
+##### `onChangeViewport` (Function)
+Callback when the viewport needs to be updated.

--- a/docs/controls/navigation-control.md
+++ b/docs/controls/navigation-control.md
@@ -5,9 +5,6 @@ This is a React equivalent of Mapbox's [NavigationControl](https://www.mapbox.co
 ```js
 import ReactMap, {Marker} from 'react-map-gl';
 
-/* Needs Mapbox's stylesheet to work! */
-import 'mapbox-gl/dist/mapbox-gl.css';
-
 export default MyMap = ({viewport, updateViewport}) => {
   return (
     <ReactMap {...viewport} onChangeViewport={updateViewport}>
@@ -18,6 +15,23 @@ export default MyMap = ({viewport, updateViewport}) => {
   );
 }
 ```
+
+## Styling
+
+Like its Mapbox counterpart, this control relies on the mapbox-gl stylesheet to work properly.
+
+You may add the stylesheet to your page:
+```
+<!-- index.html -->
+<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.37.0/mapbox-gl.css' rel='stylesheet' />
+```
+
+Or embed it in your app by using [browserify-css](https://www.npmjs.com/package/browserify-css) with Browserify or [css-loader](https://webpack.github.io/docs/stylesheets.html) with Webpack:
+```
+/// app.js
+import 'mapbox-gl/dist/mapbox-gl.css';
+```
+
 
 ## Properties
 

--- a/docs/controls/navigation-control.md
+++ b/docs/controls/navigation-control.md
@@ -5,6 +5,9 @@ This is a React equivalent of Mapbox's [NavigationControl](https://www.mapbox.co
 ```js
 import ReactMap, {Marker} from 'react-map-gl';
 
+/* Needs Mapbox's stylesheet to work! */
+import 'mapbox-gl/dist/mapbox-gl.css';
+
 export default MyMap = ({viewport, updateViewport}) => {
   return (
     <ReactMap {...viewport} onChangeViewport={updateViewport}>

--- a/examples/controls/app.css
+++ b/examples/controls/app.css
@@ -8,3 +8,10 @@ body {
   fill: #d00;
   stroke: none;
 }
+
+.nav {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 10px;
+}

--- a/examples/controls/app.js
+++ b/examples/controls/app.js
@@ -1,7 +1,7 @@
 /* global window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
-import MapGL, {Marker, Popup} from 'react-map-gl';
+import MapGL, {Marker, Popup, NavigationControl} from 'react-map-gl';
 
 import CityPin from './components/city-pin';
 
@@ -101,6 +101,10 @@ class Root extends Component {
         { CITIES.map(this._renderCityMarker) }
 
         {this._renderPopup()}
+
+        <div className="nav">
+          <NavigationControl onChangeViewport={this._updateViewport} />
+        </div>
 
       </MapGL>
     );

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -41,6 +41,13 @@ const contextTypes = {
   viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
 };
 
+/*
+ * PureComponent doesn't update when context changes.
+ * The only way is to implement our own shouldComponentUpdate here. Considering
+ * the parent component (StaticMap or InteractiveMap) is pure, and map re-render
+ * is almost always triggered by a viewport change, we almost definitely need to
+ * recalculate the marker's position when the parent re-renders.
+ */
 export default class Marker extends Component {
 
   render() {

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -22,6 +22,10 @@ const contextTypes = {
   viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
 };
 
+/*
+ * PureComponent doesn't update when context changes, so
+ * implementing our own shouldComponentUpdate here.
+ */
 export default class NavigationControl extends Component {
 
   constructor(props) {

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -1,0 +1,87 @@
+import {Component, createElement} from 'react';
+import PropTypes from 'prop-types';
+import autobind from '../utils/autobind';
+
+import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import MapState from '../utils/map-state';
+
+const propTypes = {
+  /**
+    * `onChangeViewport` callback is fired when the user interacted with the
+    * map. The object passed to the callback contains `latitude`,
+    * `longitude` and `zoom` and additional state information.
+    */
+  onChangeViewport: PropTypes.func.isRequired
+};
+
+const defaultProps = {
+  onChangeViewport: () => {}
+};
+
+const contextTypes = {
+  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
+};
+
+export default class NavigationControl extends Component {
+
+  constructor(props) {
+    super(props);
+    autobind(this);
+  }
+
+  shouldComponentUpdate(nextProps, nextState, nextContext) {
+    return this.context.viewport.bearing !== nextContext.viewport.bearing;
+  }
+
+  _updateViewport(opts) {
+    const {viewport} = this.context;
+    const mapState = new MapState({...viewport, ...opts});
+    this.props.onChangeViewport(mapState.getViewportProps());
+  }
+
+  _onZoomIn() {
+    this._updateViewport({zoom: this.context.viewport.zoom + 1});
+  }
+
+  _onZoomOut() {
+    this._updateViewport({zoom: this.context.viewport.zoom - 1});
+  }
+
+  _onResetNorth() {
+    this._updateViewport({bearing: 0});
+  }
+
+  _renderCompass() {
+    const {bearing} = this.context.viewport;
+    return createElement('span', {
+      className: 'arrow',
+      style: {transform: `rotate(${bearing}deg)`}
+    });
+  }
+
+  _renderButton(type, label, callback, children) {
+    return createElement('button', {
+      key: type,
+      className: `mapboxgl-ctrl-icon mapboxgl-ctrl-${type}`,
+      type: 'button',
+      title: label,
+      onClick: callback,
+      children
+    });
+  }
+
+  render() {
+    return createElement('div', {
+      className: 'mapboxgl-ctrl mapboxgl-ctrl-group'
+    }, [
+      this._renderButton('zoom-in', 'Zoom In', this._onZoomIn),
+      this._renderButton('zoom-out', 'Zoom Out', this._onZoomOut),
+      this._renderButton('compass', 'Reset North', this._onResetNorth, this._renderCompass())
+    ]);
+  }
+}
+
+NavigationControl.displayName = 'NavigationControl';
+NavigationControl.propTypes = propTypes;
+NavigationControl.defaultProps = defaultProps;
+NavigationControl.contextTypes = contextTypes;

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -35,7 +35,7 @@ export default class NavigationControl extends Component {
 
   _updateViewport(opts) {
     const {viewport} = this.context;
-    const mapState = new MapState({...viewport, ...opts});
+    const mapState = new MapState(Object.assign({}, viewport, opts));
     this.props.onChangeViewport(mapState.getViewportProps());
   }
 

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -62,6 +62,13 @@ const contextTypes = {
   viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
 };
 
+/*
+ * PureComponent doesn't update when context changes.
+ * The only way is to implement our own shouldComponentUpdate here. Considering
+ * the parent component (StaticMap or InteractiveMap) is pure, and map re-render
+ * is almost always triggered by a viewport change, we almost definitely need to
+ * recalculate the popup's position when the parent re-renders.
+ */
 export default class Popup extends Component {
 
   constructor(props) {

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import React, {PureComponent, createElement} from 'react';
+import {PureComponent, createElement} from 'react';
 import PropTypes from 'prop-types';
 import autobind from '../utils/autobind';
 
@@ -62,12 +62,12 @@ const propTypes = {
   /** The tile zoom level of the map. */
   zoom: PropTypes.number.isRequired,
   /** Specify the bearing of the viewport */
-  bearing: React.PropTypes.number,
+  bearing: PropTypes.number,
   /** Specify the pitch of the viewport */
-  pitch: React.PropTypes.number,
+  pitch: PropTypes.number,
   /** Altitude of the viewport camera. Default 1.5 "screen heights" */
   // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-  altitude: React.PropTypes.number,
+  altitude: PropTypes.number,
   /** The width of the map. */
   width: PropTypes.number.isRequired,
   /** The height of the map. */
@@ -188,6 +188,7 @@ export default class StaticMap extends PureComponent {
       bearing: this.props.bearing,
       style: mapStyle,
       interactive: false,
+      attributionControl: this.props.attributionControl,
       preserveDrawingBuffer: this.props.preserveDrawingBuffer
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,11 @@ export {default as InteractiveMap} from './components/interactive-map';
 export {default as StaticMap} from './components/static-map';
 export {default as MapControls} from './components/map-controls';
 export {default as Marker} from './components/marker';
+<<<<<<< HEAD
 export {default as Popup} from './components/popup';
+=======
+export {default as NavigationControl} from './components/navigation-control';
+>>>>>>> fix attribution; add navigation control
 
 export {default as default} from './components/interactive-map';
 export {default as MapGL} from './components/interactive-map';

--- a/src/index.js
+++ b/src/index.js
@@ -22,17 +22,16 @@
 export {default as InteractiveMap} from './components/interactive-map';
 export {default as StaticMap} from './components/static-map';
 export {default as MapControls} from './components/map-controls';
-export {default as Marker} from './components/marker';
-<<<<<<< HEAD
-export {default as Popup} from './components/popup';
-=======
-export {default as NavigationControl} from './components/navigation-control';
->>>>>>> fix attribution; add navigation control
 
 export {default as default} from './components/interactive-map';
 export {default as MapGL} from './components/interactive-map';
 
 // export {default as ClassicMap} from './deprecated/map';
+
+// React Controls
+export {default as Marker} from './components/marker';
+export {default as Popup} from './components/popup';
+export {default as NavigationControl} from './components/navigation-control';
 
 // Utilities
 // export {default as fitBounds} from './utils/fit-bounds';


### PR DESCRIPTION
- Fix the `attributionControl` prop on `StaticMap`
- Add `NavigationControl` (equivalent of Mapbox's [NavigationControl](https://www.mapbox.com/mapbox-gl-js/api/#navigationcontrol))