### PR TITLE
Map components props

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -73,13 +73,6 @@ const propTypes = {
   /** The height of the map. */
   height: PropTypes.number.isRequired,
 
-  /**
-   * `onChangeViewport` callback is fired when the user interacted with the
-   * map. The object passed to the callback contains `latitude`,
-   * `longitude` and `zoom` and additional state information.
-   */
-  onChangeViewport: PropTypes.func,
-
  /**
     * Called when a feature is hovered over. Uses Mapbox's
     * queryRenderedFeatures API to find features under the pointer:
@@ -125,7 +118,6 @@ const propTypes = {
 
 const defaultProps = {
   mapStyle: 'mapbox://styles/mapbox/light-v8',
-  onChangeViewport: null,
   mapboxApiAccessToken: getAccessToken(),
   preserveDrawingBuffer: false,
   attributionControl: true,

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -2,16 +2,16 @@ import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 import assert from 'assert';
 
 // MAPBOX LIMITS
-const MAX_PITCH = 60;
-const MAX_ZOOM = 20;
+export const MAPBOX_MAX_PITCH = 60;
+export const MAPBOX_MAX_ZOOM = 20;
 
 const defaultState = {
   pitch: 0,
   bearing: 0,
   altitude: 1.5,
-  maxZoom: MAX_ZOOM,
+  maxZoom: MAPBOX_MAX_ZOOM,
   minZoom: 0,
-  maxPitch: MAX_PITCH,
+  maxPitch: MAPBOX_MAX_PITCH,
   minPitch: 0
 };
 


### PR DESCRIPTION
- Remove `onChangeViewport` prop from `StaticMap`
- Add missing prop checks/documentation to `InterativeMap`
- Add new prop `ControllerClass` to `InterativeMap` that allows advanced user to replace the default map controlls