### PR TITLE
[2.0-release] add prop to disable scroll zoom

### DIFF
--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -93,7 +93,8 @@ export default class Interactions extends Component {
     onTouchEnd: PropTypes.func,
     onTouchTap: PropTypes.func,
     onZoom: PropTypes.func,
-    onZoomEnd: PropTypes.func
+    onZoomEnd: PropTypes.func,
+    scrollZoomEnabled: PropTypes.bool
   };
 
   static defaultProps = {
@@ -109,7 +110,8 @@ export default class Interactions extends Component {
     onTouchEnd: noop,
     onTouchTap: noop,
     onZoom: noop,
-    onZoomEnd: noop
+    onZoomEnd: noop,
+    scrollZoomEnabled: true
   };
 
   constructor(props) {
@@ -225,6 +227,10 @@ export default class Interactions extends Component {
   /* eslint-disable complexity, max-statements */
   @autobind
   _onWheel(event) {
+    // Exit if scroll zoom isn't enabled
+    if (!this.props.scrollZoomEnabled) {
+      return;
+    }
     event.preventDefault();
     let value = event.deltaY;
     // Firefox doubles the values on retina screens...

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -187,7 +187,13 @@ const PROP_TYPES = {
     * The load callback is called when all dependencies have been loaded and
     * the map is ready.
     */
-  onLoad: PropTypes.func
+  onLoad: PropTypes.func,
+
+  /**
+   * Prop to enable/disable scroll zoom.
+   * Defaults to true
+   */
+  scrollZoomEnabled: PropTypes.bool
 
 };
 
@@ -202,7 +208,8 @@ const DEFAULT_PROPS = {
   pitch: 0,
   altitude: 1.5,
   clickRadius: 15,
-  maxZoom: 20
+  maxZoom: 20,
+  scrollZoomEnabled: true
 };
 
 @pureRender
@@ -688,6 +695,7 @@ export default class MapGL extends Component {
           onTouchTap = { this._onTouchTap }
           onZoom ={ this._onZoom }
           onZoomEnd ={ this._onZoomEnd }
+          scrollZoomEnabled={this.props.scrollZoomEnabled}
           width ={ this.props.width }
           height ={ this.props.height }>
 


### PR DESCRIPTION
Following what was done in #134 by @cammanderson but switched it to be more consistent with the `perspectiveEnabled` pattern.

This PR is for 2.0-release and feature should be discussed for inclusion in v3.