### PR TITLE
Initial component docs

### DIFF
--- a/docs/controls/interactive-map.md
+++ b/docs/controls/interactive-map.md
@@ -1,0 +1,46 @@
+# InteractiveMap
+
+
+## Properties
+
+Additional props on top of [StaticMap]()
+
+### maxZoom (number)
+
+Max zoom level
+
+### minZoom (number)
+
+Min zoom level
+
+### maxPitch (number)
+
+Max pitch in degrees
+
+### minPitch (number)
+
+Min pitch in degrees
+
+
+### onChangeViewport
+
+`onChangeViewport` callback is fired when the user interacted with the map. The object passed to the callback contains viewport properties such as `longitude`, `latitude`, `zoom` and additional interaction state information.
+
+### perspectiveEnabled (bool)
+
+Enables perspective control event handling
+
+### isHovering (bool)
+### isDragging (bool)
+
+Is the component currently being dragged. This is used to show/hide the drag cursor. Also used as an optimization in some overlays by preventing rendering while dragging.
+
+### mapControls (shape()
+    events (arrayOf(PropTypes.string))
+    setState (func)
+    handle (fun)
+  })
+
+  // A map control instance to replace the default map controls
+  // The object must expose one property: `events` as an array of subscribed
+  // event names; and two methods: `setState(state)` and `handle(event)`

--- a/docs/controls/static-map.md
+++ b/docs/controls/static-map.md
@@ -1,0 +1,95 @@
+# StaticMap
+
+
+## Properties
+
+### mapboxApiAccessToken (string)
+
+Mapbox API access token for mapbox-gl-js. Required when using Mapbox vector tiles/styles
+Mapbox WebGL context creation option. Useful when you want to export the canvas as a PNG
+
+### preserveDrawingBuffer (bool)
+
+### attributionControl (bool)
+
+Show attribution control or not
+
+
+### mapStyle (string | Immutable.Map)
+
+The Mapbox style. A string url or a MapboxGL style Immutable.Map object
+
+
+### preventStyleDiffing (bool)
+
+There are known issues with style diffing. As stopgap, add option to prevent style diffing
+
+
+### width (number, required)
+
+The width of the map
+
+
+### height (number, required)
+
+The height of the map
+
+
+### latitude (number, required)
+
+The latitude of the center of the map
+
+
+### longitude (number, required)
+
+The longitude of the center of the map
+
+
+### zoom (number, required)
+
+The tile zoom level of the map
+
+
+### bearing (number)
+
+Specify the bearing of the viewpor
+
+
+### pitch (number)
+
+Specify the pitch of the viewpor
+
+
+### altitude (number)
+
+Altitude of the viewport camera. Default 1.5 "screen heights
+
+Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
+
+
+### onHoverFeatures (function)
+
+Called when a feature is hovered over. Uses Mapbox's
+queryRenderedFeatures API to find features under the pointer:
+https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+To query only some of the layers, set the `interactive` property in the
+layer style to `true`. See Mapbox's style spec
+https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
+If no interactive layers are found (e.g. using Mapbox's default styles),
+will fall back to query all layers.
+
+@callback
+@param {array} features - The array of features the mouse is over.
+
+
+### onClickFeatures (func)
+Called when a feature is clicked on. Uses Mapbox's queryRenderedFeatures API to find features under the pointer: https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures.
+* To query only some of the layers, set the `interactive` property in the layer style to `true`. See Mapbox's style spec https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive.
+* If no interactive layers are found (e.g. using Mapbox's default styles), will fall back to query all layers.
+
+### onClick (func)
+Called when the map is clicked. The handler is called with the clicked coordinates (https://www.mapbox.com/mapbox-gl-js/api/#LngLat) and the screen coordinates (https://www.mapbox.com/mapbox-gl-js/api/#PointLike).
+
+### clickRadius (number)
+
+Radius to detect features around a clicked point. Defaults to 15


### PR DESCRIPTION
Copied source code comments into markdown as initial versions. 

We should probably delete most of the comments in the code to avoid duplication.