### PR TITLE
Api Audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 - Remove `MapControls` React component
 - Remove `ControllerClass` prop from `InteractiveMap`
 - Add `mapControls` prop to `InteractiveMap`
+- Add `visibility` prop to `StaticMap` for showing/hiding the map
+- Rename `_getMap` method to `getMap`
+- Add `queryRenderedFeatures` method that exposes the MapboxGL API with the same name
+- Remove all interactivity related props from `StaticMap`
+- Remove intermediate state props from `InteractiveMap`: `startPanLngLat`, `startZoomLngLat`, `startBearing`, `startPitch`, `startZoom`.
+- `InteractiveMap` is now stateful (`isDragging` and `isHover`)
+- Rename `onClickFeatures` and `onHoverFeatures` to `onClick` and `onHover`. Remove `ignoreEmptyFeatures` prop. The callbacks are invoked with an event object with `features` and `lngLat` fields.
+- New `getCursor` prop of `InteractiveMap`: returns cursor style from the current map state
+- Rename `displayConstraints` to `visibilityConstraints`
+- Remove `perspectiveEnabled` prop. Add `scrollZoom`, `dragPan`, `dragRotate`, `doubleClickZoom`, `touchZoomRotate` props.
 
 ### Version 3.0.0-alpha.10 - Add `ControllerClass` prop to `InteractiveMap`
 

--- a/docs/controls/interactive-map.md
+++ b/docs/controls/interactive-map.md
@@ -3,44 +3,123 @@
 
 ## Properties
 
-Additional props on top of [StaticMap]()
+Additional props on top of [StaticMap](/docs/controls/static-map.md):
 
 ### maxZoom (number)
 
-Max zoom level
+Max zoom level.
+
+Default: `20`
+
 
 ### minZoom (number)
 
-Min zoom level
+Min zoom level.
+
+Default: `0`
+
 
 ### maxPitch (number)
 
-Max pitch in degrees
+Max pitch in degrees.
+
+Default: `60`
+
 
 ### minPitch (number)
 
-Min pitch in degrees
+Min pitch in degrees.
+
+Default: `0`
 
 
-### onChangeViewport
+### scrollZoom (bool)
 
-`onChangeViewport` callback is fired when the user interacted with the map. The object passed to the callback contains viewport properties such as `longitude`, `latitude`, `zoom` and additional interaction state information.
+Enable croll to zoom.
 
-### perspectiveEnabled (bool)
+Default: `true`
 
-Enables perspective control event handling
 
-### isHovering (bool)
-### isDragging (bool)
+### dragPan (bool)
 
-Is the component currently being dragged. This is used to show/hide the drag cursor. Also used as an optimization in some overlays by preventing rendering while dragging.
+Enable drag to pan.
 
-### mapControls (shape()
-    events (arrayOf(PropTypes.string))
-    setState (func)
-    handle (fun)
-  })
+Default: `true`
 
-  // A map control instance to replace the default map controls
-  // The object must expose one property: `events` as an array of subscribed
-  // event names; and two methods: `setState(state)` and `handle(event)`
+
+### dragRotate (bool)
+
+Enable drag to rotate.
+
+Default: `true`
+
+
+### doubleClickZoom (bool)
+
+Enable double click to zoom.
+
+Default: `true`
+
+
+### touchZoomRotate (bool)
+
+Enable touch to zoom and rotate.
+
+Default: `true`
+
+
+### onChangeViewport (function)
+
+`onChangeViewport` callback is fired when the user interacted with the map. The object passed to the callback contains viewport properties such as `longitude`, `latitude`, `zoom` etc.
+
+If the map is intended to be interactive, the app use this prop to listen to map updates and update the props accordingly.
+
+
+### mapControls (object)
+
+A map control instance to replace the default map controls.
+This object must implement the following interface:
+- `events` - An array of subscribed events
+- `handleEvent(event, context)` - A method that handles interactive events
+
+
+### onHover (function)
+
+Called when the map is hovered over.
+
+Parameters
+- `event` - The pointer event.
+  + `event.lngLat` - The geo coordinates that is being hovered.
+  + `event.features` - The array of features under the pointer, queried using Mapbox's
+    [queryRenderedFeatures](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures) API.
+    To make a layer interactive, set the `interactive` property in the layer style to `true`.
+
+
+### onClick (function)
+
+Called when the map is clicked.
+
+Parameters
+- `event` - The pointer event.
+  + `event.lngLat` - The geo coordinates that is being clicked.
+  + `event.features` - The array of features under the pointer, queried using Mapbox's
+    [queryRenderedFeatures](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures) API.
+    To make a layer interactive, set the `interactive` property in the layer style to `true`.
+
+
+### clickRadius (number)
+
+Radius to detect features around a clicked point.
+
+Default: `15`
+
+
+### getCursor (number)
+
+Accessor that returns a cursor style to show interactive state. Called when the component is being rendered.
+
+Parameters
+- `state` - The current state of the component.
+  + `state.isDragging` - If the map is being dragged.
+  + `state.isHovering` - If the pointer is over a clickable feature.
+

--- a/docs/controls/interactive-map.md
+++ b/docs/controls/interactive-map.md
@@ -123,3 +123,7 @@ Parameters
   + `state.isDragging` - If the map is being dragged.
   + `state.isHovering` - If the pointer is over a clickable feature.
 
+
+## Methods
+
+Same methods as [StaticMap](/docs/controls/static-map.md).

--- a/docs/controls/static-map.md
+++ b/docs/controls/static-map.md
@@ -81,6 +81,7 @@ Specify the pitch of the viewpor.
 
 Default: `0`
 
+
 ### altitude (number)
 
 Altitude of the viewport camera.
@@ -89,9 +90,27 @@ Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
 
 Default: `1.5` (screen heights)
 
+
 ### visible (bool)
 
 Whether the map is visible. Unmounting and re-mounting a Mapbox instance is known to be costly.
 This option offers a way to hide a map using CSS style.
 
 Default: `true`
+
+
+## Methods
+
+### getMap
+
+Returns the Mapbox instance if initialized.
+
+
+### queryRenderedFeatures
+
+Use Mapbox's `queryRenderedFeatures` API to find features at point or in a bounding box. If the `parameters` argument is not specified, only queries the layers with the `interactive` property in the layer style.
+
+Parameters:
+- `geometry` ([Number, Number]|[[Number, Number], [Number, Number]]) - Point or an array of two points defining the bounding box. Coordinates in pixels.
+- `parameters` - Query options. For more details, see [Mapbox API documentation](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures).
+

--- a/docs/controls/static-map.md
+++ b/docs/controls/static-map.md
@@ -8,88 +8,90 @@
 Mapbox API access token for mapbox-gl-js. Required when using Mapbox vector tiles/styles
 Mapbox WebGL context creation option. Useful when you want to export the canvas as a PNG
 
+
 ### preserveDrawingBuffer (bool)
+
+Equivalent to Mapbox's `preserveDrawingBuffer` [option](https://www.mapbox.com/mapbox-gl-js/api/#map).
+If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`.
+
+Default: `false`
+
 
 ### attributionControl (bool)
 
-Show attribution control or not
+Equivalent to Mapbox's `attributionControl` [option](https://www.mapbox.com/mapbox-gl-js/api/#map).
+If `true`, shows Mapbox's attribution control.
+
+Default: `true`
 
 
 ### mapStyle (string | Immutable.Map)
 
-The Mapbox style. A string url or a MapboxGL style Immutable.Map object
+The Mapbox style. A string url or a [MapboxGL style](https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive) [`Immutable.Map`](https://facebook.github.io/immutable-js/) object.
 
 
 ### preventStyleDiffing (bool)
 
-There are known issues with style diffing. As stopgap, add option to prevent style diffing
+If `mapStyle` is assigned an Immutable object, when the prop changes, `StaticMap` can diff
+between the two values and call the appropriate Mapbox API such as `addLayer`, `removeLayer`,
+`setStyle`, `setData`, etc. This allows apps to update data sources and layer styles efficiently.
+In use cases such as animation or dynamic showing/hiding layers, style diffing prevents the
+map from reloading and flickering when the map style changes.
+
+There are known issues with style diffing. As stopgap, use this option to prevent style diffing.
+
+Default: `false`
 
 
 ### width (number, required)
 
-The width of the map
+The width of the map.
 
 
 ### height (number, required)
 
-The height of the map
+The height of the map.
 
 
 ### latitude (number, required)
 
-The latitude of the center of the map
+The latitude of the center of the map.
 
 
 ### longitude (number, required)
 
-The longitude of the center of the map
+The longitude of the center of the map.
 
 
 ### zoom (number, required)
 
-The tile zoom level of the map
+The tile zoom level of the map.
 
 
 ### bearing (number)
 
-Specify the bearing of the viewpor
+Specify the bearing of the viewpor.
+
+Default: `0`
 
 
 ### pitch (number)
 
-Specify the pitch of the viewpor
+Specify the pitch of the viewpor.
 
+Default: `0`
 
 ### altitude (number)
 
-Altitude of the viewport camera. Default 1.5 "screen heights
+Altitude of the viewport camera.
 
 Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
 
+Default: `1.5` (screen heights)
 
-### onHoverFeatures (function)
+### visible (bool)
 
-Called when a feature is hovered over. Uses Mapbox's
-queryRenderedFeatures API to find features under the pointer:
-https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
-To query only some of the layers, set the `interactive` property in the
-layer style to `true`. See Mapbox's style spec
-https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
-If no interactive layers are found (e.g. using Mapbox's default styles),
-will fall back to query all layers.
+Whether the map is visible. Unmounting and re-mounting a Mapbox instance is known to be costly.
+This option offers a way to hide a map using CSS style.
 
-@callback
-@param {array} features - The array of features the mouse is over.
-
-
-### onClickFeatures (func)
-Called when a feature is clicked on. Uses Mapbox's queryRenderedFeatures API to find features under the pointer: https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures.
-* To query only some of the layers, set the `interactive` property in the layer style to `true`. See Mapbox's style spec https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive.
-* If no interactive layers are found (e.g. using Mapbox's default styles), will fall back to query all layers.
-
-### onClick (func)
-Called when the map is clicked. The handler is called with the clicked coordinates (https://www.mapbox.com/mapbox-gl-js/api/#LngLat) and the screen coordinates (https://www.mapbox.com/mapbox-gl-js/api/#PointLike).
-
-### clickRadius (number)
-
-Radius to detect features around a clicked point. Defaults to 15
+Default: `true`

--- a/examples/custom-interactions/view.js
+++ b/examples/custom-interactions/view.js
@@ -80,9 +80,7 @@ export default class Example extends Component {
         longitude: location.longitude,
         zoom: 11,
         bearing: 180,
-        pitch: 60,
-        startDragLngLat: null,
-        isDragging: false
+        pitch: 60
       },
       mapStyle: buildStyle({stroke: '#FF00FF', fill: 'green'})
     };
@@ -107,8 +105,8 @@ export default class Example extends Component {
     this.setState({viewport: opt});
   }
 
-  _onClickFeatures(features) {
-    window.console.log(features);
+  _onClickFeatures(event) {
+    window.console.log(event.features);
   }
 
   render() {
@@ -122,8 +120,7 @@ export default class Example extends Component {
         { ...viewport }
         maxPitch={85}
         onChangeViewport={ this._onChangeViewport }
-        onClickFeatures={ this._onClickFeatures }
-        perspectiveEnabled={ true }
+        onClick={ this._onClickFeatures }
         // setting to `true` should cause the map to flicker because all sources
         // and layers need to be reloaded without diffing enabled.
         preventStyleDiffing={ false }>

--- a/examples/custom-interactions/view.js
+++ b/examples/custom-interactions/view.js
@@ -105,10 +105,6 @@ export default class Example extends Component {
     this.setState({viewport: opt});
   }
 
-  _onMapLoaded(event) {
-    window.console.log(event);
-  }
-
   _onClickFeatures(event) {
     window.console.log(event.features);
   }
@@ -124,7 +120,6 @@ export default class Example extends Component {
         { ...viewport }
         maxPitch={85}
         onChangeViewport={ this._onChangeViewport }
-        onLoad={ this._onMapLoaded }
         onClick={ this._onClickFeatures }
         // setting to `true` should cause the map to flicker because all sources
         // and layers need to be reloaded without diffing enabled.

--- a/examples/custom-interactions/view.js
+++ b/examples/custom-interactions/view.js
@@ -105,6 +105,10 @@ export default class Example extends Component {
     this.setState({viewport: opt});
   }
 
+  _onMapLoaded(event) {
+    window.console.log(event);
+  }
+
   _onClickFeatures(event) {
     window.console.log(event.features);
   }
@@ -120,6 +124,7 @@ export default class Example extends Component {
         { ...viewport }
         maxPitch={85}
         onChangeViewport={ this._onChangeViewport }
+        onLoad={ this._onMapLoaded }
         onClick={ this._onClickFeatures }
         // setting to `true` should cause the map to flicker because all sources
         // and layers need to be reloaded without diffing enabled.

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -44,19 +44,25 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
   touchZoomRotateEnabled: PropTypes.bool,
 
  /**
-    * Called when a feature is hovered over. Uses Mapbox's
-    * queryRenderedFeatures API to find features under the pointer:
+    * Called when the map is hovered over.
+    * @callback
+    * @param {Object} event - The mouse event.
+    * @param {[Number, Number]} event.lngLat - The coordinates of the pointer
+    * @param {Array} event.features - The features under the pointer, using Mapbox's
+    * queryRenderedFeatures API:
     * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
     * To make a layer interactive, set the `interactive` property in the
     * layer style to `true`. See Mapbox's style spec
     * https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
-    * @callback
-    * @param {array} features - The array of features the mouse is over.
     */
   onHover: PropTypes.func,
   /**
-    * Called when a feature is clicked on. Uses Mapbox's
-    * queryRenderedFeatures API to find features under the pointer:
+    * Called when the map is clicked.
+    * @callback
+    * @param {Object} event - The mouse event.
+    * @param {[Number, Number]} event.lngLat - The coordinates of the pointer
+    * @param {Array} event.features - The features under the pointer, using Mapbox's
+    * queryRenderedFeatures API:
     * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
     * To make a layer interactive, set the `interactive` property in the
     * layer style to `true`. See Mapbox's style spec

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -97,7 +97,7 @@ const getDefaultCursor = ({isDragging, isHovering}) => isDragging ?
   config.CURSOR.GRABBING :
   (isHovering ? config.CURSOR.POINTER : config.CURSOR.GRAB);
 
-const defaultProps = Object.assign({}, StaticMap.defaultProps, {
+const defaultProps = Object.assign({}, StaticMap.defaultProps, MAPBOX_LIMITS, {
   onChangeViewport: null,
   onClick: null,
   onHover: null,
@@ -110,9 +110,6 @@ const defaultProps = Object.assign({}, StaticMap.defaultProps, {
 
   clickRadius: 0,
   getCursor: getDefaultCursor,
-
-  /** Viewport constraints */
-  ...MAPBOX_LIMITS,
 
   visibilityConstraints: MAPBOX_LIMITS,
 

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -31,10 +31,8 @@ import isBrowser from '../utils/is-browser';
 import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 
 let mapboxgl = null;
-let Point = null;
 if (isBrowser) {
   mapboxgl = require('mapbox-gl');
-  ({Point} = mapboxgl);
 }
 
 function noop() {}
@@ -54,11 +52,17 @@ const propTypes = {
   ]),
   /** There are known issues with style diffing. As stopgap, add option to prevent style diffing. */
   preventStyleDiffing: PropTypes.bool,
+  /** Whether the map is visible */
+  visible: PropTypes.bool,
 
-  /** The latitude of the center of the map. */
-  latitude: PropTypes.number.isRequired,
+  /** The width of the map. */
+  width: PropTypes.number.isRequired,
+  /** The height of the map. */
+  height: PropTypes.number.isRequired,
   /** The longitude of the center of the map. */
   longitude: PropTypes.number.isRequired,
+  /** The latitude of the center of the map. */
+  latitude: PropTypes.number.isRequired,
   /** The tile zoom level of the map. */
   zoom: PropTypes.number.isRequired,
   /** Specify the bearing of the viewport */
@@ -68,52 +72,9 @@ const propTypes = {
   /** Altitude of the viewport camera. Default 1.5 "screen heights" */
   // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
   altitude: PropTypes.number,
-  /** The width of the map. */
-  width: PropTypes.number.isRequired,
-  /** The height of the map. */
-  height: PropTypes.number.isRequired,
 
- /**
-    * Called when a feature is hovered over. Uses Mapbox's
-    * queryRenderedFeatures API to find features under the pointer:
-    * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
-    * To query only some of the layers, set the `interactive` property in the
-    * layer style to `true`. See Mapbox's style spec
-    * https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
-    * If no interactive layers are found (e.g. using Mapbox's default styles),
-    * will fall back to query all layers.
-    * @callback
-    * @param {array} features - The array of features the mouse is over.
-    */
-  onHoverFeatures: PropTypes.func,
-  /**
-    * Set to false to enable onHoverFeatures to be called regardless if
-    * there is an actual feature at x, y. This is useful to emulate
-    * "mouse-out" behaviors on features.
-    * Defaults to TRUE
-    */
-  ignoreEmptyFeatures: PropTypes.bool,
-  /**
-    * Called when a feature is clicked on. Uses Mapbox's
-    * queryRenderedFeatures API to find features under the pointer:
-    * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
-    * To query only some of the layers, set the `interactive` property in the
-    * layer style to `true`. See Mapbox's style spec
-    * https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive
-    * If no interactive layers are found (e.g. using Mapbox's default styles),
-    * will fall back to query all layers.
-    */
-  onClickFeatures: PropTypes.func,
-
-  /**
-   * Called when the map is clicked. The handler is called with the clicked
-   * coordinates (https://www.mapbox.com/mapbox-gl-js/api/#LngLat) and the
-   * screen coordinates (https://www.mapbox.com/mapbox-gl-js/api/#PointLike).
-   */
-  onClick: PropTypes.func,
-
-  /** Radius to detect features around a clicked point. Defaults to 15. */
-  clickRadius: PropTypes.number
+  /** Callback when the map is loaded */
+  onLoad: PropTypes.func
 };
 
 const defaultProps = {
@@ -121,11 +82,10 @@ const defaultProps = {
   mapboxApiAccessToken: getAccessToken(),
   preserveDrawingBuffer: false,
   attributionControl: true,
-  ignoreEmptyFeatures: true,
+  visible: true,
   bearing: 0,
   pitch: 0,
-  altitude: 1.5,
-  clickRadius: 15
+  altitude: 1.5
 };
 
 const childContextTypes = {
@@ -232,8 +192,18 @@ export default class StaticMap extends PureComponent {
   }
 
   // External apps can access map this way
-  _getMap() {
+  getMap() {
     return this._map;
+  }
+
+  /** Uses Mapbox's
+    * queryRenderedFeatures API to find features at point or in a bounding box.
+    * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+    * To query only some of the layers, set the `interactive` property in the
+    * layer style to `true`.
+    */
+  queryRenderedFeatures(geometry) {
+    this._map.queryRenderedFeatures(geometry, this._queryParams);
   }
 
   _updateStateFromProps(oldProps, newProps) {
@@ -404,60 +374,14 @@ export default class StaticMap extends PureComponent {
     }
   }
 
-  _getFeatures({pos, radius}) {
-    let features;
-    if (radius) {
-      // Radius enables point features, like marker symbols, to be clicked.
-      const size = radius;
-      const bbox = [[pos[0] - size, pos[1] - size], [pos[0] + size, pos[1] + size]];
-      features = this._map.queryRenderedFeatures(bbox, this._queryParams);
-    } else {
-      const point = new Point(...pos);
-      features = this._map.queryRenderedFeatures(point, this._queryParams);
-    }
-    return features;
-  }
-
-  // HOVER AND CLICK
-
-  _onMouseMove({pos}) {
-    if (this.props.onHover) {
-      const latLong = this.props.unproject(pos);
-      this.props.onHover(latLong, pos);
-    }
-    if (this.props.onHoverFeatures) {
-      const features = this._getFeatures({pos});
-      if (!features.length && this.props.ignoreEmptyFeatures) {
-        return;
-      }
-      this.setState({isHovering: features.length > 0});
-      this.props.onHoverFeatures(features);
-    }
-  }
-
-  _onMouseClick(event) {
-    const pos = [event.clientX, event.clientY];
-
-    if (this.props.onClick) {
-      const latLong = this.props.unproject(pos);
-      // TODO - Do we really want to expose a mapbox "Point" in our interface?
-      // const point = new Point(...pos);
-      this.props.onClick(latLong, pos);
-    }
-
-    if (this.props.onClickFeatures) {
-      const features = this._getFeatures({pos, radius: this.props.clickRadius});
-      if (!features.length && this.props.ignoreEmptyFeatures) {
-        return;
-      }
-      this.props.onClickFeatures(features);
-    }
-  }
-
   render() {
-    const {className, width, height, style} = this.props;
+    const {className, width, height, style, visible} = this.props;
     const mapContainerStyle = Object.assign({}, style, {width, height, position: 'relative'});
-    const mapStyle = Object.assign({}, style, {width, height});
+    const mapStyle = Object.assign({}, style, {
+      width,
+      height,
+      visibility: visible ? 'visible' : 'hidden'
+    });
     const overlayContainerStyle = {
       position: 'absolute',
       left: 0,
@@ -472,8 +396,6 @@ export default class StaticMap extends PureComponent {
       createElement('div', {
         key: 'map-container',
         style: mapContainerStyle,
-        onMouseMove: this._onMouseMove,
-        onClick: this._onMouseClick,
         children: [
           createElement('div', {
             key: 'map-mapbox',

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -71,10 +71,7 @@ const propTypes = {
   pitch: PropTypes.number,
   /** Altitude of the viewport camera. Default 1.5 "screen heights" */
   // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-  altitude: PropTypes.number,
-
-  /** Callback when the map is loaded */
-  onLoad: PropTypes.func
+  altitude: PropTypes.number
 };
 
 const defaultProps = {
@@ -82,11 +79,11 @@ const defaultProps = {
   mapboxApiAccessToken: getAccessToken(),
   preserveDrawingBuffer: false,
   attributionControl: true,
+  preventStyleDiffing: false,
   visible: true,
   bearing: 0,
   pitch: 0,
-  altitude: 1.5,
-  onLoad: () => {}
+  altitude: 1.5
 };
 
 const childContextTypes = {
@@ -143,9 +140,6 @@ export default class StaticMap extends PureComponent {
     if (canvas) {
       canvas.style.outline = 'none';
     }
-
-    // Listen to `load` event
-    map.on('load', this.props.onLoad);
 
     this._map = map;
     this._updateMapViewport({}, this.props);

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -52,7 +52,7 @@ export default class MapControls {
    * Callback for events
    * @param {hammer.Event} event
    */
-  handle(event, options) {
+  handleEvent(event, options) {
     this.mapState = new MapState(Object.assign({}, options, this._state));
     this.setOptions(options);
 
@@ -123,19 +123,19 @@ export default class MapControls {
   setOptions({
     onChangeViewport,
     onChangeState,
-    scrollZoomEnabled = true,
-    dragPanEnabled = true,
-    dragRotateEnabled = true,
-    doubleClickZoomEnabled = true,
-    touchZoomRotateEnabled = true
+    scrollZoom = true,
+    dragPan = true,
+    dragRotate = true,
+    doubleClickZoom = true,
+    touchZoomRotate = true
   }) {
     this.onChangeViewport = onChangeViewport;
     this.onChangeState = onChangeState;
-    this.scrollZoomEnabled = scrollZoomEnabled;
-    this.dragPanEnabled = dragPanEnabled;
-    this.dragRotateEnabled = dragRotateEnabled;
-    this.doubleClickZoomEnabled = doubleClickZoomEnabled;
-    this.touchZoomRotateEnabled = touchZoomRotateEnabled;
+    this.scrollZoom = scrollZoom;
+    this.dragPan = dragPan;
+    this.dragRotate = dragRotate;
+    this.doubleClickZoom = doubleClickZoom;
+    this.touchZoomRotate = touchZoomRotate;
   }
 
   /* Event handlers */
@@ -160,7 +160,7 @@ export default class MapControls {
   // Default handler for panning to move.
   // Called by `_onPan` when panning without function key pressed.
   _onPanMove(event) {
-    if (!this.dragPanEnabled) {
+    if (!this.dragPan) {
       return false;
     }
     const pos = this.getCenter(event);
@@ -171,7 +171,7 @@ export default class MapControls {
   // Default handler for panning to rotate.
   // Called by `_onPan` when panning with function key pressed.
   _onPanRotate(event) {
-    if (!this.dragRotateEnabled) {
+    if (!this.dragRotate) {
       return false;
     }
 
@@ -202,7 +202,7 @@ export default class MapControls {
 
   // Default handler for the `wheel` event.
   _onWheel(event) {
-    if (!this.scrollZoomEnabled) {
+    if (!this.scrollZoom) {
       return false;
     }
     const pos = this.getCenter(event);
@@ -227,7 +227,7 @@ export default class MapControls {
 
   // Default handler for the `pinch` event.
   _onPinch(event) {
-    if (!this.touchZoomRotateEnabled) {
+    if (!this.touchZoomRotate) {
       return false;
     }
     const pos = this.getCenter(event);
@@ -244,7 +244,7 @@ export default class MapControls {
 
   // Default handler for the `doubletap` event.
   _onDoubleTap(event) {
-    if (!this.doubleClickZoomEnabled) {
+    if (!this.doubleClickZoom) {
       return false;
     }
     const pos = this.getCenter(event);

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import MapState from '../utils/map-state';
+
 // EVENT HANDLING PARAMETERS
 const PITCH_MOUSE_THRESHOLD = 5;
 const PITCH_ACCEL = 1.2;
@@ -41,25 +43,19 @@ export default class MapControls {
    */
   constructor() {
     this.events = SUBSCRIBED_EVENTS;
-  }
-
-  /**
-   * Update the state of the control
-   * @param {MapState} state.mapState - current map state
-   * @param {Function} state.onChangeViewport - callback
-   */
-  setState({mapState, onChangeViewport, isDragging, perspectiveEnabled}) {
-    this.mapState = mapState;
-    this.onChangeViewport = onChangeViewport;
-    this.isDragging = isDragging;
-    this.perspectiveEnabled = perspectiveEnabled;
+    this._state = {
+      isDragging: false
+    };
   }
 
   /**
    * Callback for events
    * @param {hammer.Event} event
    */
-  handle(event) {
+  handle(event, options) {
+    this.mapState = new MapState(Object.assign({}, options, this._state));
+    this._setOptions(options);
+
     switch (event.type) {
     case 'panstart':
       return this._onPanStart(event);
@@ -99,18 +95,47 @@ export default class MapControls {
       srcEvent.ctrlKey || srcEvent.shiftKey);
   }
 
+  setState(newState) {
+    Object.assign(this._state, newState);
+    if (this.onChangeState) {
+      this.onChangeState(this._state);
+    }
+  }
+
   /* Callback util */
   // formats map state and invokes callback function
-  updateViewport(mapState, extraState = {}) {
-    if (!this.onChangeViewport) {
-      return false;
+  updateViewport(newMapState, extraState = {}) {
+    const oldViewport = this.mapState.getViewportProps();
+    const newViewport = newMapState.getViewportProps();
+
+    if (this.onChangeViewport &&
+      Object.keys(newViewport).some(key => oldViewport[key] !== newViewport[key])) {
+      // Viewport has changed
+      this.onChangeViewport(newViewport);
     }
 
-    return this.onChangeViewport(Object.assign(
-      {isDragging: this.isDragging},
-      mapState.getViewportProps(),
-      extraState
-    ));
+    this.setState(Object.assign({}, newMapState.getInteractiveState(), extraState));
+  }
+
+  /**
+   * Extract interactivity options
+   */
+  _setOptions({
+    onChangeViewport,
+    onChangeState,
+    scrollZoomEnabled = true,
+    dragPanEnabled = true,
+    dragRotateEnabled = true,
+    doubleClickZoomEnabled = true,
+    touchZoomRotateEnabled = true
+  }) {
+    this.onChangeViewport = onChangeViewport;
+    this.onChangeState = onChangeState;
+    this.scrollZoomEnabled = scrollZoomEnabled;
+    this.dragPanEnabled = dragPanEnabled;
+    this.dragRotateEnabled = dragRotateEnabled;
+    this.doubleClickZoomEnabled = doubleClickZoomEnabled;
+    this.touchZoomRotateEnabled = touchZoomRotateEnabled;
   }
 
   /* Event handlers */
@@ -135,6 +160,9 @@ export default class MapControls {
   // Default handler for panning to move.
   // Called by `_onPan` when panning without function key pressed.
   _onPanMove(event) {
+    if (!this.dragPanEnabled) {
+      return false;
+    }
     const pos = this.getCenter(event);
     const newMapState = this.mapState.pan({pos});
     return this.updateViewport(newMapState);
@@ -143,7 +171,7 @@ export default class MapControls {
   // Default handler for panning to rotate.
   // Called by `_onPan` when panning with function key pressed.
   _onPanRotate(event) {
-    if (!this.perspectiveEnabled) {
+    if (!this.dragRotateEnabled) {
       return false;
     }
 
@@ -174,6 +202,9 @@ export default class MapControls {
 
   // Default handler for the `wheel` event.
   _onWheel(event) {
+    if (!this.scrollZoomEnabled) {
+      return false;
+    }
     const pos = this.getCenter(event);
     const {delta} = event;
 
@@ -196,6 +227,9 @@ export default class MapControls {
 
   // Default handler for the `pinch` event.
   _onPinch(event) {
+    if (!this.touchZoomRotateEnabled) {
+      return false;
+    }
     const pos = this.getCenter(event);
     const {scale} = event;
     const newMapState = this.mapState.zoom({pos, scale});
@@ -210,6 +244,9 @@ export default class MapControls {
 
   // Default handler for the `doubletap` event.
   _onDoubleTap(event) {
+    if (!this.doubleClickZoomEnabled) {
+      return false;
+    }
     const pos = this.getCenter(event);
     const isZoomOut = this.isFunctionKeyPressed(event);
 

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -54,7 +54,7 @@ export default class MapControls {
    */
   handle(event, options) {
     this.mapState = new MapState(Object.assign({}, options, this._state));
-    this._setOptions(options);
+    this.setOptions(options);
 
     switch (event.type) {
     case 'panstart':
@@ -120,7 +120,7 @@ export default class MapControls {
   /**
    * Extract interactivity options
    */
-  _setOptions({
+  setOptions({
     onChangeViewport,
     onChangeState,
     scrollZoomEnabled = true,

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -2,17 +2,17 @@ import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 import assert from 'assert';
 
 // MAPBOX LIMITS
-export const MAPBOX_MAX_PITCH = 60;
-export const MAPBOX_MAX_ZOOM = 20;
+export const MAPBOX_LIMITS = {
+  minZoom: 0,
+  maxZoom: 20,
+  minPitch: 0,
+  maxPitch: 60
+};
 
 const defaultState = {
   pitch: 0,
   bearing: 0,
-  altitude: 1.5,
-  maxZoom: MAPBOX_MAX_ZOOM,
-  minZoom: 0,
-  maxPitch: MAPBOX_MAX_PITCH,
-  minPitch: 0
+  altitude: 1.5
 };
 
 /* Utils */
@@ -83,10 +83,10 @@ export default class MapState {
       bearing: ensureFinite(bearing, defaultState.bearing),
       pitch: ensureFinite(pitch, defaultState.pitch),
       altitude: ensureFinite(altitude, defaultState.altitude),
-      maxZoom: ensureFinite(maxZoom, defaultState.maxZoom),
-      minZoom: ensureFinite(minZoom, defaultState.minZoom),
-      maxPitch: ensureFinite(maxPitch, defaultState.maxPitch),
-      minPitch: ensureFinite(minPitch, defaultState.minPitch)
+      maxZoom: ensureFinite(maxZoom, MAPBOX_LIMITS.maxZoom),
+      minZoom: ensureFinite(minZoom, MAPBOX_LIMITS.minZoom),
+      maxPitch: ensureFinite(maxPitch, MAPBOX_LIMITS.maxPitch),
+      minPitch: ensureFinite(minPitch, MAPBOX_LIMITS.minPitch)
     });
 
     this._interactiveState = {

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -74,7 +74,7 @@ export default class MapState {
     assert(Number.isFinite(latitude), '`latitude` must be supplied');
     assert(Number.isFinite(zoom), '`zoom` must be supplied');
 
-    this._state = this._applyConstraints({
+    this._viewportProps = this._applyConstraints({
       width,
       height,
       latitude,
@@ -86,19 +86,26 @@ export default class MapState {
       maxZoom: ensureFinite(maxZoom, defaultState.maxZoom),
       minZoom: ensureFinite(minZoom, defaultState.minZoom),
       maxPitch: ensureFinite(maxPitch, defaultState.maxPitch),
-      minPitch: ensureFinite(minPitch, defaultState.minPitch),
+      minPitch: ensureFinite(minPitch, defaultState.minPitch)
+    });
+
+    this._interactiveState = {
       startPanLngLat,
       startZoomLngLat,
       startBearing,
       startPitch,
       startZoom
-    });
+    };
   }
 
   /* Public API */
 
   getViewportProps() {
-    return this._state;
+    return this._viewportProps;
+  }
+
+  getInteractiveState() {
+    return this._interactiveState;
   }
 
   /**
@@ -118,7 +125,7 @@ export default class MapState {
    *   the start of the operation. Must be supplied of `panStart()` was not called
    */
   pan({pos, startPos}) {
-    const startPanLngLat = this._state.startPanLngLat || this._unproject(startPos);
+    const startPanLngLat = this._interactiveState.startPanLngLat || this._unproject(startPos);
 
     // take the start lnglat and put it where the mouse is down.
     assert(startPanLngLat, '`startPanLngLat` prop is required ' +
@@ -148,8 +155,8 @@ export default class MapState {
    */
   rotateStart({pos}) {
     return this._getUpdatedMapState({
-      startBearing: this._state.bearing,
-      startPitch: this._state.pitch
+      startBearing: this._viewportProps.bearing,
+      startPitch: this._viewportProps.pitch
     });
   }
 
@@ -166,13 +173,13 @@ export default class MapState {
     assert(deltaScaleY >= -1 && deltaScaleY <= 1,
       '`deltaScaleY` must be a number between [-1, 1]');
 
-    let {startBearing, startPitch} = this._state;
+    let {startBearing, startPitch} = this._interactiveState;
 
     if (!Number.isFinite(startBearing)) {
-      startBearing = this._state.bearing;
+      startBearing = this._viewportProps.bearing;
     }
     if (!Number.isFinite(startPitch)) {
-      startPitch = this._state.pitch;
+      startPitch = this._viewportProps.pitch;
     }
 
     const {pitch, bearing} = this._calculateNewPitchAndBearing({
@@ -206,7 +213,7 @@ export default class MapState {
   zoomStart({pos}) {
     return this._getUpdatedMapState({
       startZoomLngLat: this._unproject(pos),
-      startZoom: this._state.zoom
+      startZoom: this._viewportProps.zoom
     });
   }
 
@@ -222,12 +229,12 @@ export default class MapState {
     assert(scale > 0, '`scale` must be a positive number');
 
     // Make sure we zoom around the current mouse position rather than map center
-    const startZoomLngLat = this._state.startZoomLngLat ||
+    const startZoomLngLat = this._interactiveState.startZoomLngLat ||
       this._unproject(startPos) || this._unproject(pos);
-    let {startZoom} = this._state;
+    let {startZoom} = this._interactiveState;
 
     if (!Number.isFinite(startZoom)) {
-      startZoom = this._state.zoom;
+      startZoom = this._viewportProps.zoom;
     }
 
     // take the start lnglat and put it where the mouse is down.
@@ -236,7 +243,9 @@ export default class MapState {
 
     const zoom = this._calculateNewZoom({scale, startZoom});
 
-    const zoomedViewport = new PerspectiveMercatorViewport(Object.assign({}, this._state, {zoom}));
+    const zoomedViewport = new PerspectiveMercatorViewport(
+      Object.assign({}, this._viewportProps, {zoom})
+    );
     const [longitude, latitude] = zoomedViewport.getLocationAtPoint({lngLat: startZoomLngLat, pos});
 
     return this._getUpdatedMapState({
@@ -260,11 +269,11 @@ export default class MapState {
   /* Private methods */
 
   _getUpdatedMapState(newProps) {
-    // Update _state
-    return new MapState(Object.assign({}, this._state, newProps));
+    // Update _viewportProps
+    return new MapState(Object.assign({}, this._viewportProps, this._interactiveState, newProps));
   }
 
-  // Apply any constraints (mathematical or defined by _state) to map state
+  // Apply any constraints (mathematical or defined by _viewportProps) to map state
   _applyConstraints(props) {
     // Normalize degrees
     props.longitude = mod(props.longitude + 180, 360) - 180;
@@ -285,19 +294,19 @@ export default class MapState {
   }
 
   _unproject(pos) {
-    const viewport = new PerspectiveMercatorViewport(this._state);
+    const viewport = new PerspectiveMercatorViewport(this._viewportProps);
     return pos && viewport.unproject(pos, {topLeft: false});
   }
 
   // Calculate a new lnglat based on pixel dragging position
   _calculateNewLngLat({startPanLngLat, pos}) {
-    const viewport = new PerspectiveMercatorViewport(this._state);
+    const viewport = new PerspectiveMercatorViewport(this._viewportProps);
     return viewport.getLocationAtPoint({lngLat: startPanLngLat, pos});
   }
 
   // Calculates new zoom
   _calculateNewZoom({scale, startZoom}) {
-    const {maxZoom, minZoom} = this._state;
+    const {maxZoom, minZoom} = this._viewportProps;
     let zoom = startZoom + Math.log2(scale);
     zoom = zoom > maxZoom ? maxZoom : zoom;
     zoom = zoom < minZoom ? minZoom : zoom;
@@ -306,7 +315,7 @@ export default class MapState {
 
   // Calculates a new pitch and bearing from a position (coming from an event)
   _calculateNewPitchAndBearing({deltaScaleX, deltaScaleY, startBearing, startPitch}) {
-    const {minPitch, maxPitch} = this._state;
+    const {minPitch, maxPitch} = this._viewportProps;
 
     const bearing = startBearing + 180 * deltaScaleX;
     let pitch = startPitch;


### PR DESCRIPTION
- Add `visibility` prop to `StaticMap` for showing/hiding the map
- Add `onLoad` prop to both components, called when the MapboxGL instance is loaded
- Rename `_getMap` method to `getMap`
- Add `queryRenderedFeatures` method that exposes the MapboxGL API with the same name
- Remove all interactivity related props from `StaticMap`
- Remove intermediate state props from `InteractiveMap`: `startPanLngLat`, `startZoomLngLat`, `startBearing`, `startPitch`, `startZoom`. These are stored in the map controls.
- `InteractiveMap` is now stateful (`isDragging` and `isHover`)
- Rename `onClickFeatures` and `onHoverFeatures` to `onClick` and `onHover`. Remove `ignoreEmptyFeatures` prop. The callbacks are invoked with an event object with `features` and `lngLat` fields.
- New `getCursor` prop of `InteractiveMap`: returns cursor style from the current map state
- Rename `displayConstraints` to `visibilityConstraints`
- Remove `perspectiveEnabled` prop. Add `scrollZoom`, `dragPan`, `dragRotate`, `doubleClickZoom`, `touchZoomRotate` props.