### PR TITLE
Fix flickering bug when drag over popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 [TBD]
 - New: `fitBounds` util function
+- Fix: Map flickering when drag over popups
 
 ### Version 3.0.0-alpha.11
 - New event management system based on hammer.js

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -184,6 +184,13 @@ export default class InteractiveMap extends PureComponent {
     const controlOptions = Object.assign({}, this.props, {
       onChangeState: this._onInteractiveStateChange
     });
+    /*
+     * The map control needs `event.target` to calculate pointer positions
+     * relative to the map.
+     * If an overlay is interactive, when dragging over it, it becomes the
+     * `event.target`. Overwrite it with the event canvas here.
+     * The original target element is accessible in `event.srcEvent`.
+     */
     event.target = this.refs.eventCanvas;
     return this.props.mapControls.handleEvent(event, controlOptions);
   }

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -184,14 +184,6 @@ export default class InteractiveMap extends PureComponent {
     const controlOptions = Object.assign({}, this.props, {
       onChangeState: this._onInteractiveStateChange
     });
-    /*
-     * The map control needs `event.target` to calculate pointer positions
-     * relative to the map.
-     * If an overlay is interactive, when dragging over it, it becomes the
-     * `event.target`. Overwrite it with the event canvas here.
-     * The original target element is accessible in `event.srcEvent`.
-     */
-    event.target = this.refs.eventCanvas;
     return this.props.mapControls.handleEvent(event, controlOptions);
   }
 
@@ -246,12 +238,11 @@ export default class InteractiveMap extends PureComponent {
 
   // HOVER AND CLICK
   _getPos(event) {
-    const target = this.refs.eventCanvas;
-    const {srcEvent: {clientX, clientY}} = event;
-    const rect = target.getBoundingClientRect();
+    const {srcEvent: {clientX, clientY}, srcElement} = event;
+    const rect = srcElement.getBoundingClientRect();
     return [
-      clientX - rect.left - target.clientLeft,
-      clientY - rect.top - target.clientTop
+      clientX - rect.left - srcElement.clientLeft,
+      clientY - rect.top - srcElement.clientTop
     ];
   }
 

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -238,11 +238,11 @@ export default class InteractiveMap extends PureComponent {
 
   // HOVER AND CLICK
   _getPos(event) {
-    const {srcEvent: {clientX, clientY}, srcElement} = event;
-    const rect = srcElement.getBoundingClientRect();
+    const {srcEvent: {clientX, clientY}, rootElement} = event;
+    const rect = rootElement.getBoundingClientRect();
     return [
-      clientX - rect.left - srcElement.clientLeft,
-      clientY - rect.top - srcElement.clientTop
+      clientX - rect.left - rootElement.clientLeft,
+      clientY - rect.top - rootElement.clientTop
     ];
   }
 

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -184,6 +184,7 @@ export default class InteractiveMap extends PureComponent {
     const controlOptions = Object.assign({}, this.props, {
       onChangeState: this._onInteractiveStateChange
     });
+    event.target = this.refs.eventCanvas;
     return this.props.mapControls.handleEvent(event, controlOptions);
   }
 
@@ -238,7 +239,8 @@ export default class InteractiveMap extends PureComponent {
 
   // HOVER AND CLICK
   _getPos(event) {
-    const {srcEvent: {clientX, clientY}, target} = event;
+    const target = this.refs.eventCanvas;
+    const {srcEvent: {clientX, clientY}} = event;
     const rect = target.getBoundingClientRect();
     return [
       clientX - rect.left - target.clientLeft,

--- a/src/utils/event-manager/event-manager.js
+++ b/src/utils/event-manager/event-manager.js
@@ -42,6 +42,7 @@ export default class EventManager {
     // TODO: support overriding default RECOGNIZERS by passing
     // recognizers / configs, keyed to event name.
 
+    this.element = element;
     this._onBasicInput = this._onBasicInput.bind(this);
     this.manager = new Manager(element, {recognizers: RECOGNIZERS})
       .on('hammer.input', this._onBasicInput);
@@ -137,6 +138,9 @@ export default class EventManager {
    * See constants.BASIC_EVENT_CLASSES basic event class definitions.
    */
   _onBasicInput(event) {
+    // For calculating pointer position relative to the canvas
+    event.srcElement = this.element;
+
     const {srcEvent} = event;
     const eventAliases = BASIC_EVENT_ALIASES[srcEvent.type];
     if (eventAliases) {
@@ -153,6 +157,9 @@ export default class EventManager {
    * and pipe back out through same (Hammer) channel used by other events.
    */
   _onOtherEvent(event) {
+    // For calculating pointer position relative to the canvas
+    event.srcElement = this.element;
+
     const {srcEvent: {type}} = event;
     this.manager.emit(type, event);
   }

--- a/src/utils/event-manager/event-manager.js
+++ b/src/utils/event-manager/event-manager.js
@@ -139,7 +139,7 @@ export default class EventManager {
    */
   _onBasicInput(event) {
     // For calculating pointer position relative to the canvas
-    event.srcElement = this.element;
+    event.rootElement = this.element;
 
     const {srcEvent} = event;
     const eventAliases = BASIC_EVENT_ALIASES[srcEvent.type];
@@ -158,7 +158,7 @@ export default class EventManager {
    */
   _onOtherEvent(event) {
     // For calculating pointer position relative to the canvas
-    event.srcElement = this.element;
+    event.rootElement = this.element;
 
     const {srcEvent: {type}} = event;
     this.manager.emit(type, event);

--- a/src/utils/event-manager/move-input.js
+++ b/src/utils/event-manager/move-input.js
@@ -26,7 +26,7 @@ export default class MoveInput {
   handler(event) {
     this.callback({
       srcEvent: event,
-      target: this.element
+      target: event.target
     });
   }
 }

--- a/src/utils/event-manager/wheel-input.js
+++ b/src/utils/event-manager/wheel-input.js
@@ -121,7 +121,7 @@ export default class WheelInput {
       center: position,
       delta,
       srcEvent,
-      target: this.element
+      target: srcEvent.target
     });
   }
 }

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -81,11 +81,11 @@ export default class MapControls {
   /* Event utils */
   // Event object: http://hammerjs.github.io/api/#event-object
   getCenter(event) {
-    const {center, srcElement} = event;
-    const rect = srcElement.getBoundingClientRect();
+    const {center, rootElement} = event;
+    const rect = rootElement.getBoundingClientRect();
     return [
-      center.x - rect.left - srcElement.clientLeft,
-      center.y - rect.top - srcElement.clientTop
+      center.x - rect.left - rootElement.clientLeft,
+      center.y - rect.top - rootElement.clientTop
     ];
   }
 

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -81,11 +81,11 @@ export default class MapControls {
   /* Event utils */
   // Event object: http://hammerjs.github.io/api/#event-object
   getCenter(event) {
-    const {center, target} = event;
-    const rect = target.getBoundingClientRect();
+    const {center, srcElement} = event;
+    const rect = srcElement.getBoundingClientRect();
     return [
-      center.x - rect.left - target.clientLeft,
-      center.y - rect.top - target.clientTop
+      center.x - rect.left - srcElement.clientLeft,
+      center.y - rect.top - srcElement.clientTop
     ];
   }
 


### PR DESCRIPTION
Problem: hammer.js uses client coordinates to recognize gestures, which is the expected behavior. When we calculate the pointer position relative to the map, we used to assume `event.target` is the container. However, if an overlay element is interactive, when dragging the pointer over it, it becomes the `event.target`.

This conversion is also needed in deck.gl. Should we handle it inside the EventManager instead?
