### PR TITLE
Clarifying webpack 2 example location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@
 
 * `browserify` - react-map-gl is extensively tested with `browserify` and works without configuration.
 
-* `webpack 1` - look at the [exhibit-webpack](https://github.com/uber/react-map-gl/tree/master/examples/exhibit-webpack)
+* `webpack 2` - look at the [exhibit-webpack](https://github.com/uber/react-map-gl/tree/master/examples/exhibit-webpack)
 folder, demonstrating a working demo using `webpack`.
-
-* `webpack 2` - The dev branch in this repo is based on webpack 2, look at the webpack config file in the main example.
 
 In general, for non-browserify based environments, make sure you have read the instructions on the
 [mapbox-gl-js README](https://github.com/mapboxmapbox-gl-js#using-mapbox-gl-js-with-other-module-systems).


### PR DESCRIPTION
Master has webpack 2 example: exhibit-webpack

The `dev` branch pointer sent me in the wrong direction when trying to get this working with webpack 2. 

This is a small change, but should help people orient themselves when starting development with react-map-gl.