### PR TITLE
Add onLoad callback to static map props and componentDidMount

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -145,7 +145,7 @@ export default class StaticMap extends PureComponent {
     }
 
     // Attach optional onLoad function
-    map.once('load', () => this.props.onLoad());
+    map.once('load', this.props.onLoad);
 
     this._map = map;
     this._updateMapViewport({}, this.props);

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -85,7 +85,8 @@ const defaultProps = {
   visible: true,
   bearing: 0,
   pitch: 0,
-  altitude: 1.5
+  altitude: 1.5,
+  onLoad: noop
 };
 
 const childContextTypes = {
@@ -144,9 +145,7 @@ export default class StaticMap extends PureComponent {
     }
 
     // Attach optional onLoad function
-    if (this.props.onLoad) {
-      map.once('load', () => this.props.onLoad());
-    }
+    map.once('load', () => this.props.onLoad());
 
     this._map = map;
     this._updateMapViewport({}, this.props);

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -71,7 +71,9 @@ const propTypes = {
   pitch: PropTypes.number,
   /** Altitude of the viewport camera. Default 1.5 "screen heights" */
   // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-  altitude: PropTypes.number
+  altitude: PropTypes.number,
+  /** The onLoad callback for the map */
+  onLoad: PropTypes.func
 };
 
 const defaultProps = {
@@ -139,6 +141,11 @@ export default class StaticMap extends PureComponent {
     const canvas = map.getCanvas();
     if (canvas) {
       canvas.style.outline = 'none';
+    }
+
+    // Attach optional onLoad function
+    if (this.props.onLoad) {
+      map.once('load', () => this.props.onLoad());
     }
 
     this._map = map;


### PR DESCRIPTION
This PR is in reference to #267 

The current test in `components/map.spec.js` seems to only test that an onLoad prop doesn't interfere with initialization, since InteractiveMap.supported returns false. I'm likely missing something relevant to unit testing this project.

The code is mostly pulled from the previous 2.0 releases. I'd prefer to get the unit test working before merging in, but I wanted some eyes from you guys before venturing down that path. 

Like issue #267 references, is onLoad planned for v3 support? Please let me know if this PR is either unwarranted or veers away from v3 plans @ibgreen.