### PR TITLE
Change `pan` event listener to move specific `panmove`

### DIFF
--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -27,7 +27,7 @@ const ZOOM_ACCEL = 0.01;
 
 const SUBSCRIBED_EVENTS = [
   'panstart',
-  'pan',
+  'panmove',
   'panend',
   'pinchstart',
   'pinch',
@@ -59,7 +59,7 @@ export default class MapControls {
     switch (event.type) {
     case 'panstart':
       return this._onPanStart(event);
-    case 'pan':
+    case 'panmove':
       return this._onPan(event);
     case 'panend':
       return this._onPanEnd(event);
@@ -149,7 +149,7 @@ export default class MapControls {
     return this.updateViewport(newMapState, {isDragging: true});
   }
 
-  // Default handler for the `pan` event.
+  // Default handler for the `panmove` event.
   _onPan(event) {
     return this.isFunctionKeyPressed(event) ? this._onPanRotate(event) : this._onPanMove(event);
   }


### PR DESCRIPTION
At the end of a pinch on a touchscreen device, a directional pan event is often fired (presumably because you don't remove your fingers in perfect unison).  Because this is listening to Hammer's generic `pan` event, it catches the directional pan event and tries to move the map without ever having set a start position. That throws an assertion error and (for reasons I don't fully understand) recognizes all following events as pinches.  Switching to `panmove` will eliminate that extra event noise and keep things functioning properly.