### PR TITLE
Fix compass arrow in navigation control

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,15 @@
+# Testing
+
+```
+npm run test
+npm run test-browser
+```
+
+## Bumping Mapbox Version
+
+Always pin Mapbox to a specific release.
+
+The React controls (`NavigationControl`, `Popup` and `Marker`) are dependent on
+the Mapbox stylesheet, and may be broken by Mapbox updates.
+Always run `examples/controls` after bumping Mapbox version to make sure they
+still work.

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -64,7 +64,7 @@ export default class NavigationControl extends Component {
   _renderCompass() {
     const {bearing} = this.context.viewport;
     return createElement('span', {
-      className: 'arrow',
+      className: 'mapboxgl-ctrl-compass-arrow',
       style: {transform: `rotate(${bearing}deg)`}
     });
   }


### PR DESCRIPTION
We have a dependency on the mapbox stylesheet, so bumping mapbox version could potentially break the controls.
Alternatively we could export a stylesheet in our library...