### PR TITLE
Fix StaticMap error when created on node

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -102,7 +102,9 @@ export default class StaticMap extends PureComponent {
     super(props);
 
     this._queryParams = {};
-    mapboxgl.accessToken = props.mapboxApiAccessToken;
+    if (mapboxgl) {
+      mapboxgl.accessToken = props.mapboxApiAccessToken;
+    }
 
     if (!StaticMap.supported()) {
       this.componentDidMount = noop;
@@ -211,7 +213,9 @@ export default class StaticMap extends PureComponent {
   }
 
   _updateStateFromProps(oldProps, newProps) {
-    mapboxgl.accessToken = newProps.mapboxApiAccessToken;
+    if (mapboxgl) {
+      mapboxgl.accessToken = newProps.mapboxApiAccessToken;
+    }
   }
 
   // Hover and click only query layers whose interactive property is true


### PR DESCRIPTION
Check if `mapboxgl` is imported before assigning `accessToken`