### PR TITLE
move babel configs from package.json to webpack config to fix doc build issues

### DIFF
--- a/examples/controls/package.json
+++ b/examples/controls/package.json
@@ -17,12 +17,5 @@
     "babel-preset-stage-2": "^6.18.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/controls/webpack.config.js
+++ b/examples/controls/webpack.config.js
@@ -5,6 +5,16 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
 const config = {
   entry: {
     app: resolve('./src/root.js')
@@ -16,9 +26,12 @@ const config = {
     rules: [{
       // Compile ES2015 using bable
       test: /\.js$/,
-      loader: 'babel-loader',
       include: [resolve('.')],
-      exclude: [/node_modules/]
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
     }]
   },
 

--- a/examples/controls/webpack.config.js
+++ b/examples/controls/webpack.config.js
@@ -5,6 +5,10 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
     'es2015',

--- a/examples/geojson-animation/package.json
+++ b/examples/geojson-animation/package.json
@@ -17,12 +17,5 @@
     "babel-preset-stage-2": "^6.18.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/geojson-animation/webpack.config.js
+++ b/examples/geojson-animation/webpack.config.js
@@ -5,6 +5,16 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
 const config = {
   entry: {
     app: resolve('./src/root.js')
@@ -16,9 +26,12 @@ const config = {
     rules: [{
       // Compile ES2015 using bable
       test: /\.js$/,
-      loader: 'babel-loader',
       include: [resolve('.')],
-      exclude: [/node_modules/]
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
     }]
   },
 

--- a/examples/geojson-animation/webpack.config.js
+++ b/examples/geojson-animation/webpack.config.js
@@ -5,6 +5,10 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
     'es2015',

--- a/examples/geojson/package.json
+++ b/examples/geojson/package.json
@@ -19,12 +19,5 @@
     "babel-preset-stage-2": "^6.18.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/geojson/webpack.config.js
+++ b/examples/geojson/webpack.config.js
@@ -5,6 +5,16 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
 const config = {
   entry: {
     app: resolve('./src/root.js')
@@ -23,9 +33,12 @@ const config = {
     rules: [{
       // Compile ES2015 using bable
       test: /\.js$/,
-      loader: 'babel-loader',
       include: [resolve('.')],
-      exclude: [/node_modules/]
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
     }]
   },
 

--- a/examples/geojson/webpack.config.js
+++ b/examples/geojson/webpack.config.js
@@ -5,6 +5,10 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
     'es2015',

--- a/examples/interaction/package.json
+++ b/examples/interaction/package.json
@@ -17,12 +17,5 @@
     "babel-preset-stage-2": "^6.18.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/interaction/webpack.config.js
+++ b/examples/interaction/webpack.config.js
@@ -5,6 +5,16 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
 const config = {
   entry: {
     app: resolve('./src/root.js')
@@ -16,9 +26,12 @@ const config = {
     rules: [{
       // Compile ES2015 using bable
       test: /\.js$/,
-      loader: 'babel-loader',
       include: [resolve('.')],
-      exclude: [/node_modules/]
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
     }]
   },
 

--- a/examples/interaction/webpack.config.js
+++ b/examples/interaction/webpack.config.js
@@ -5,6 +5,10 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
     'es2015',

--- a/examples/layers/package.json
+++ b/examples/layers/package.json
@@ -17,12 +17,5 @@
     "babel-preset-stage-2": "^6.18.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/layers/webpack.config.js
+++ b/examples/layers/webpack.config.js
@@ -5,6 +5,16 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
 const config = {
   entry: {
     app: resolve('./src/root.js')
@@ -16,9 +26,12 @@ const config = {
     rules: [{
       // Compile ES2015 using bable
       test: /\.js$/,
-      loader: 'babel-loader',
       include: [resolve('.')],
-      exclude: [/node_modules/]
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
     }]
   },
 

--- a/examples/layers/webpack.config.js
+++ b/examples/layers/webpack.config.js
@@ -5,6 +5,10 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
     'es2015',

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -14,7 +14,8 @@
     "immutable": "^3.8.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-map-gl": ">=3.0.0-alpha.14"
+    "react-map-gl": ">=3.0.0-alpha.14",
+    "tween.js": "^16.6.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.2.0",
@@ -29,12 +30,5 @@
     "style-loader": "^0.18.2",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/main/webpack.config.js
+++ b/examples/main/webpack.config.js
@@ -2,7 +2,8 @@
 const {resolve} = require('path');
 const webpack = require('webpack');
 
-// Otherwise modules imported from outside this directory does not compile
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
 // Seems to be a Babel bug
 // https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {

--- a/examples/main/webpack.config.js
+++ b/examples/main/webpack.config.js
@@ -51,11 +51,15 @@ const config = {
   },
 
   resolve: {
+    modules: [
+      // Always resolve module to this app's node_modules first
+      resolve('./node_modules'),
+      'node_modules'
+    ],
     alias: {
-      // Ensure only one copy of react
-      react: resolve('./node_modules/react'),
-      immutable: resolve('./node_modules/immutable'),
-      // Per mapbox-gl-js README for non-browserify bundlers
+      // used by Mapbox
+      webworkify: 'webworkify-webpack-dropin',
+      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
       'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
     }
   },

--- a/examples/viewport-animation/package.json
+++ b/examples/viewport-animation/package.json
@@ -18,12 +18,5 @@
     "babel-preset-stage-2": "^6.18.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
   }
 }

--- a/examples/viewport-animation/webpack.config.js
+++ b/examples/viewport-animation/webpack.config.js
@@ -5,6 +5,16 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
 const config = {
   entry: {
     app: resolve('./src/root.js')
@@ -16,9 +26,12 @@ const config = {
     rules: [{
       // Compile ES2015 using bable
       test: /\.js$/,
-      loader: 'babel-loader',
       include: [resolve('.')],
-      exclude: [/node_modules/]
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
     }]
   },
 

--- a/examples/viewport-animation/webpack.config.js
+++ b/examples/viewport-animation/webpack.config.js
@@ -5,6 +5,10 @@
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
     'es2015',

--- a/website/package.json
+++ b/website/package.json
@@ -14,12 +14,11 @@
     "lint": "eslint src --ignore-pattern workers"
   },
   "dependencies": {
-    "autobind-decorator": "^1.3.3",
-    "babel-polyfill": "^6.1.19",
-    "babel-register": "^6.22.0",
     "d3-color": "^1.0.1",
     "d3-request": "^1.0.5",
     "d3-scale": "^1.0.6",
+    "d3-array": "^1.2.0",
+    "d3-random": "^1.1.0",
     "highlight.js": "^9.7.0",
     "immutable": "^3.7.5",
     "marked": "^0.3.6",
@@ -39,14 +38,14 @@
     "babel-cli": "^6.3.15",
     "babel-core": "^6.7.7",
     "babel-eslint": "^7.0.0",
-    "babel-loader": "^6.2.10",
+    "babel-loader": "^7.1.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
     "brfs-babel": "^1.0.0",
     "copy-webpack-plugin": "^4.0.1",
-    "css-loader": "^0.26.1",
+    "css-loader": "^0.28.4",
     "eslint": "^3.0.0",
     "eslint-config-uber-es2015": "^3.0.0",
     "eslint-config-uber-jsx": "^3.0.0",
@@ -59,20 +58,12 @@
     "style-loader": "^0.13.1",
     "transform-loader": "^0.2.3",
     "url-loader": "^0.5.7",
-    "webpack": "^2.2.0",
+    "webpack": "^2.6.1",
     "webpack-dev-server": "^1.16.2",
     "webpack-hot-middleware": "^2.17.0",
     "webworkify-webpack-dropin": "^1.1.9"
   },
   "babel": {
-    "presets": [
-      "react",
-      "es2015",
-      "stage-2"
-    ],
-    "plugins": [
-      "transform-decorators-legacy"
-    ],
     "env": {
       "test": {
         "plugins": [

--- a/website/src/components/input.js
+++ b/website/src/components/input.js
@@ -1,9 +1,8 @@
 import React, {PureComponent} from 'react';
-import autobind from 'autobind-decorator';
 
 export default class GenericInput extends PureComponent {
 
-  @autobind _onChange(evt) {
+  _onChange = (evt) => {
     const {value, type} = evt.target;
     let newValue = value;
     if (type === 'checkbox') {

--- a/website/src/components/page.js
+++ b/website/src/components/page.js
@@ -2,7 +2,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import autobind from 'autobind-decorator';
 
 import MarkdownPage from './markdown-page';
 import {loadContent, updateMap} from '../actions/app-actions';
@@ -38,7 +37,7 @@ class Page extends Component {
   }
 
   // replaces the current query string in react-router
-  @autobind _updateQueryString(queryString) {
+  _updateQueryString = (queryString) => {
     const {location: {pathname, search}} = this.props;
     if (search !== queryString) {
       this.context.router.replace({

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -1,7 +1,4 @@
 /* global document */
-import 'babel-polyfill';
-import 'babel-register';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';

--- a/website/webpack/config.js
+++ b/website/webpack/config.js
@@ -46,10 +46,12 @@ module.exports = {
   },
 
   resolve: {
+    modules: [
+      // Always resolve module to this app's node_modules first
+      resolve('./node_modules'),
+      'node_modules'
+    ],
     alias: {
-      // Ensure only one copy of react
-      react: resolve('./node_modules/react'),
-      immutable: resolve('./node_modules/immutable'),
       // used by Mapbox
       webworkify: 'webworkify-webpack-dropin',
       // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):


### PR DESCRIPTION
Looks like all the build issues resulted from having `babel` config inside of `package.json`. I don't know why.

But removing them from `package.json` and putting into `webpack.config.js` solved all the things. Individual examples still work as well.

Also ensured modules are resolved to the working directory first before the imported file's directory with `modules`.

The doc website should build great now, simply go into `website/`, then `yarn && npm run start` and voila.