### PR TITLE
Add/remove event handlers based on user setting

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -112,9 +112,7 @@ const defaultProps = Object.assign({}, StaticMap.defaultProps, MAPBOX_LIMITS, {
   clickRadius: 0,
   getCursor: getDefaultCursor,
 
-  visibilityConstraints: MAPBOX_LIMITS,
-
-  mapControls: new MapControls()
+  visibilityConstraints: MAPBOX_LIMITS
 });
 
 const childContextTypes = {
@@ -140,6 +138,10 @@ export default class InteractiveMap extends PureComponent {
       // Whether the cursor is over a clickable feature
       isHovering: false
     };
+
+    // If props.mapControls is not provided, fallback to default MapControls instance
+    // Cannot use defaultProps here because it needs to be per map instance
+    this._mapControls = props.mapControls || new MapControls();
   }
 
   getChildContext() {
@@ -151,7 +153,6 @@ export default class InteractiveMap extends PureComponent {
 
   componentDidMount() {
     const {eventCanvas} = this.refs;
-    const {mapControls} = this.props;
 
     const eventManager = new EventManager(eventCanvas);
 
@@ -160,14 +161,14 @@ export default class InteractiveMap extends PureComponent {
     eventManager.on('click', this._onMouseClick);
     this._eventManager = eventManager;
 
-    mapControls.setOptions(Object.assign({}, this.props, {
+    this._mapControls.setOptions(Object.assign({}, this.props, {
       onStateChange: this._onInteractiveStateChange,
       eventManager
     }));
   }
 
   componentWillUpdate(nextProps) {
-    this.props.mapControls.setOptions(nextProps);
+    this._mapControls.setOptions(nextProps);
   }
 
   componentWillUnmount() {

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -112,7 +112,9 @@ const defaultProps = Object.assign({}, StaticMap.defaultProps, MAPBOX_LIMITS, {
   clickRadius: 0,
   getCursor: getDefaultCursor,
 
-  visibilityConstraints: MAPBOX_LIMITS
+  visibilityConstraints: MAPBOX_LIMITS,
+
+  mapControls: new MapControls()
 });
 
 const childContextTypes = {
@@ -149,7 +151,7 @@ export default class InteractiveMap extends PureComponent {
 
   componentDidMount() {
     const {eventCanvas} = this.refs;
-    const mapControls = this.props.mapControls || new MapControls();
+    const {mapControls} = this.props;
 
     const eventManager = new EventManager(eventCanvas);
 
@@ -162,11 +164,10 @@ export default class InteractiveMap extends PureComponent {
       onStateChange: this._onInteractiveStateChange,
       eventManager
     }));
-    this._mapControls = mapControls;
   }
 
   componentWillUpdate(nextProps) {
-    this._mapControls.setOptions(nextProps);
+    this.props.mapControls.setOptions(nextProps);
   }
 
   componentWillUnmount() {

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -112,9 +112,7 @@ const defaultProps = Object.assign({}, StaticMap.defaultProps, MAPBOX_LIMITS, {
   clickRadius: 0,
   getCursor: getDefaultCursor,
 
-  visibilityConstraints: MAPBOX_LIMITS,
-
-  mapControls: new MapControls()
+  visibilityConstraints: MAPBOX_LIMITS
 });
 
 const childContextTypes = {
@@ -151,20 +149,24 @@ export default class InteractiveMap extends PureComponent {
 
   componentDidMount() {
     const {eventCanvas} = this.refs;
-    const {mapControls} = this.props;
+    const mapControls = this.props.mapControls || new MapControls();
 
-    // Register event handlers defined by map controls
-    const events = {};
-    mapControls.events.forEach(eventName => {
-      events[eventName] = this._handleEvent;
-    });
-
-    const eventManager = new EventManager(eventCanvas, {events});
+    const eventManager = new EventManager(eventCanvas);
 
     // Register additional event handlers for click and hover
     eventManager.on('mousemove', this._onMouseMove);
     eventManager.on('click', this._onMouseClick);
     this._eventManager = eventManager;
+
+    mapControls.setOptions(Object.assign({}, this.props, {
+      onStateChange: this._onInteractiveStateChange,
+      eventManager
+    }));
+    this._mapControls = mapControls;
+  }
+
+  componentWillUpdate(nextProps) {
+    this._mapControls.setOptions(nextProps);
   }
 
   componentWillUnmount() {
@@ -172,13 +174,6 @@ export default class InteractiveMap extends PureComponent {
       // Must destroy because hammer adds event listeners to window
       this._eventManager.destroy();
     }
-  }
-
-  _handleEvent(event) {
-    const controlOptions = Object.assign({}, this.props, {
-      onStateChange: this._onInteractiveStateChange
-    });
-    return this.props.mapControls.handleEvent(event, controlOptions);
   }
 
   getMap() {

--- a/src/utils/event-manager/constants.js
+++ b/src/utils/event-manager/constants.js
@@ -33,7 +33,6 @@ export const BASIC_EVENT_ALIASES = {
  * this block maps event names to the Recognizers required to detect the events.
  */
 export const EVENT_RECOGNIZER_MAP = {
-  click: 'tap',
   tap: 'tap',
   doubletap: 'doubletap',
   press: 'press',

--- a/src/utils/event-manager/event-manager.js
+++ b/src/utils/event-manager/event-manager.js
@@ -107,27 +107,32 @@ export default class EventManager {
     }
   }
 
+  /*
+   * Enable/disable recognizer for the given event
+   */
+  _enableRecognizer(name, enabled) {
+    const recognizer = this.manager.get(name);
+    if (recognizer) {
+      recognizer.set({enable: enabled});
+    }
+    this.wheelInput.enableIfEventSupported(name, enabled);
+    this.moveInput.enableIfEventSupported(name, enabled);
+  }
+
   /**
    * Process the event registration for a single event + handler.
    */
   _addEventHandler(event, handler) {
-    // Special handling for gestural events.
-    const recognizerEvent = EVENT_RECOGNIZER_MAP[event];
-    if (recognizerEvent) {
-      // Enable recognizer for this event.
-      const recognizer = this.manager.get(recognizerEvent);
-      recognizer.set({enable: true});
-    }
-
-    this.wheelInput.enableIfEventSupported(event);
-    this.moveInput.enableIfEventSupported(event);
-
     const wrappedHandler = this._wrapEventHandler(event, handler);
     // Alias to a recognized gesture as necessary.
     const eventAlias = GESTURE_EVENT_ALIASES[event] || event;
+    // Get recognizer for this event
+    const recognizerName = EVENT_RECOGNIZER_MAP[eventAlias] || eventAlias;
+    // Enable recognizer for this event.
+    this._enableRecognizer(recognizerName, true);
 
     // Save wrapped handler
-    this.eventHandlers.push({event, eventAlias, handler, wrappedHandler});
+    this.eventHandlers.push({event, eventAlias, recognizerName, handler, wrappedHandler});
 
     this.manager.on(eventAlias, wrappedHandler);
   }
@@ -136,6 +141,8 @@ export default class EventManager {
    * Process the event deregistration for a single event + handler.
    */
   _removeEventHandler(event, handler) {
+    let success = false;
+
     // Find saved handler if any.
     for (let i = this.eventHandlers.length; i--;) {
       const entry = this.eventHandlers[i];
@@ -144,6 +151,21 @@ export default class EventManager {
         this.manager.off(entry.eventAlias, entry.wrappedHandler);
         // Delete saved handler
         this.eventHandlers.splice(i, 1);
+        success = true;
+      }
+    }
+
+    if (success) {
+      // Alias to a recognized gesture as necessary.
+      const eventAlias = GESTURE_EVENT_ALIASES[event] || event;
+      // Get recognizer for this event
+      const recognizerName = EVENT_RECOGNIZER_MAP[eventAlias] || eventAlias;
+      // Disable recognizer if no more handlers are attached to its events
+      const isRecognizerUsed = this.eventHandlers.find(
+        entry => entry.recognizerName === recognizerName
+      );
+      if (!isRecognizerUsed) {
+        this._enableRecognizer(recognizerName, false);
       }
     }
   }

--- a/src/utils/event-manager/event-manager.js
+++ b/src/utils/event-manager/event-manager.js
@@ -110,13 +110,13 @@ export default class EventManager {
   /*
    * Enable/disable recognizer for the given event
    */
-  _enableRecognizer(name, enabled) {
+  _toggleRecognizer(name, enabled) {
     const recognizer = this.manager.get(name);
     if (recognizer) {
       recognizer.set({enable: enabled});
     }
-    this.wheelInput.enableIfEventSupported(name, enabled);
-    this.moveInput.enableIfEventSupported(name, enabled);
+    this.wheelInput.toggleIfEventSupported(name, enabled);
+    this.moveInput.toggleIfEventSupported(name, enabled);
   }
 
   /**
@@ -129,7 +129,7 @@ export default class EventManager {
     // Get recognizer for this event
     const recognizerName = EVENT_RECOGNIZER_MAP[eventAlias] || eventAlias;
     // Enable recognizer for this event.
-    this._enableRecognizer(recognizerName, true);
+    this._toggleRecognizer(recognizerName, true);
 
     // Save wrapped handler
     this.eventHandlers.push({event, eventAlias, recognizerName, handler, wrappedHandler});
@@ -165,7 +165,7 @@ export default class EventManager {
         entry => entry.recognizerName === recognizerName
       );
       if (!isRecognizerUsed) {
-        this._enableRecognizer(recognizerName, false);
+        this._toggleRecognizer(recognizerName, false);
       }
     }
   }

--- a/src/utils/event-manager/move-input.js
+++ b/src/utils/event-manager/move-input.js
@@ -1,5 +1,5 @@
 const MOUSE_EVENTS = ['mousedown', 'mousemove', 'mouseup'];
-const MOVE_EVENT_TYPES = ['mousemove', 'pointermove'];
+const EVENT_TYPE = 'pointermove';
 
 /**
  * Hammer.js swallows 'move' events (for pointer/touch/mouse)
@@ -35,9 +35,9 @@ export default class MoveInput {
    * Enable this input (begin processing events)
    * if the specified event type is among those handled by this input.
    */
-  enableIfEventSupported(eventType) {
-    if (MOVE_EVENT_TYPES.indexOf(eventType) >= 0) {
-      this.options.enable = true;
+  enableIfEventSupported(eventType, enabled) {
+    if (EVENT_TYPE === eventType) {
+      this.options.enable = enabled;
     }
   }
 
@@ -62,12 +62,12 @@ export default class MoveInput {
       if (!this.pressed) {
         // Drag events are emitted by hammer already
         // we just need to emit the move event on hover
-        MOVE_EVENT_TYPES.forEach(type => this.callback({
-          type,
+        this.callback({
+          type: EVENT_TYPE,
           srcEvent: event,
           pointerType: 'mouse',
           target: event.target
-        }));
+        });
       }
       break;
     case 'mouseup':

--- a/src/utils/event-manager/move-input.js
+++ b/src/utils/event-manager/move-input.js
@@ -35,7 +35,7 @@ export default class MoveInput {
    * Enable this input (begin processing events)
    * if the specified event type is among those handled by this input.
    */
-  enableIfEventSupported(eventType, enabled) {
+  toggleIfEventSupported(eventType, enabled) {
     if (EVENT_TYPE === eventType) {
       this.options.enable = enabled;
     }

--- a/src/utils/event-manager/wheel-input.js
+++ b/src/utils/event-manager/wheel-input.js
@@ -53,7 +53,7 @@ export default class WheelInput {
    * Enable this input (begin processing events)
    * if the specified event type is among those handled by this input.
    */
-  enableIfEventSupported(eventType, enabled) {
+  toggleIfEventSupported(eventType, enabled) {
     if (eventType === EVENT_TYPE) {
       this.options.enable = enabled;
     }

--- a/src/utils/event-manager/wheel-input.js
+++ b/src/utils/event-manager/wheel-input.js
@@ -53,9 +53,9 @@ export default class WheelInput {
    * Enable this input (begin processing events)
    * if the specified event type is among those handled by this input.
    */
-  enableIfEventSupported(eventType) {
+  enableIfEventSupported(eventType, enabled) {
     if (eventType === EVENT_TYPE) {
-      this.options.enable = true;
+      this.options.enable = enabled;
     }
   }
 
@@ -64,6 +64,7 @@ export default class WheelInput {
     if (!this.options.enable) {
       return;
     }
+    event.preventDefault();
 
     let value = event.deltaY;
     if (window.WheelEvent) {

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -26,10 +26,10 @@ const PITCH_ACCEL = 1.2;
 const ZOOM_ACCEL = 0.01;
 
 const EVENT_TYPES = {
-  wheel: ['wheel'],
-  pan: ['panstart', 'panmove', 'panend'],
-  pinch: ['pinchstart', 'pinchmove', 'pinchend'],
-  doubletap: ['doubletap']
+  WHEEL: ['wheel'],
+  PAN: ['panstart', 'panmove', 'panend'],
+  PINCH: ['pinchstart', 'pinchmove', 'pinchend'],
+  DOUBLE_TAP: ['doubletap']
 };
 
 export default class MapControls {
@@ -41,7 +41,6 @@ export default class MapControls {
     this._state = {
       isDragging: false
     };
-    this._events = {};
     this.handleEvent = this.handleEvent.bind(this);
   }
 
@@ -129,14 +128,18 @@ export default class MapControls {
     // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
     this.onViewportChange = onViewportChange || onChangeViewport;
     this.onStateChange = onStateChange;
-    this.eventManager = eventManager;
     this.mapStateProps = options;
+    if (this.eventManager !== eventManager) {
+      // EventManager has changed
+      this.eventManager = eventManager;
+      this._events = {};
+    }
 
     // Register/unregister events
-    this.enableEvents(EVENT_TYPES.wheel, scrollZoom);
-    this.enableEvents(EVENT_TYPES.pan, dragPan || dragRotate);
-    this.enableEvents(EVENT_TYPES.pinch, touchZoomRotate);
-    this.enableEvents(EVENT_TYPES.doubletap, doubleClickZoom);
+    this.toggleEvents(EVENT_TYPES.WHEEL, scrollZoom);
+    this.toggleEvents(EVENT_TYPES.PAN, dragPan || dragRotate);
+    this.toggleEvents(EVENT_TYPES.PINCH, touchZoomRotate);
+    this.toggleEvents(EVENT_TYPES.DOUBLE_TAP, doubleClickZoom);
 
     // Interaction toggles
     this.scrollZoom = scrollZoom;
@@ -146,7 +149,7 @@ export default class MapControls {
     this.touchZoomRotate = touchZoomRotate;
   }
 
-  enableEvents(eventNames, enabled) {
+  toggleEvents(eventNames, enabled) {
     if (this.eventManager) {
       eventNames.forEach(eventName => {
         if (this._events[eventName] !== enabled) {


### PR DESCRIPTION
This is to fix https://github.com/uber/react-map-gl/issues/307
*Problem*
`EventManager.emit` is async, and therefore `event.preventDefault` may not be effective in handlers.
When scrollZoom is disabled, we need to unregister the event instead of filter it out in the handler.

*Changes*
- Disable recognizers in `EventManager.off` if no more handlers are attached
- Let `MapControls` manage its own events by passing in the `EventManager` instance
