### PR TITLE
Fix InteractiveMap failure when StaticMap is rendered with error

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -152,7 +152,9 @@ export default class InteractiveMap extends PureComponent {
   }
 
   componentDidMount() {
-    const {eventCanvas} = this.refs;
+    const {eventCanvas, staticMap} = this.refs;
+
+    this._map = staticMap;
 
     const eventManager = new EventManager(eventCanvas);
 
@@ -286,9 +288,7 @@ export default class InteractiveMap extends PureComponent {
       },
         createElement(StaticMap, Object.assign({}, this.props, {
           visible: this.checkVisibilityConstraints(this.props),
-          ref: map => {
-            this._map = map;
-          }
+          ref: 'staticMap'
         }))
       )
     );


### PR DESCRIPTION
Problem reported by @heshan0131:
The `ref` callback on `StaticMap` is executed in every render pass, and called with `null` if there's an error during render.

Solution:
Remove `ref` callback and save reference once in `componentDidMount`.