### PR TITLE
Remove MAPBOX_ACCESS_TOKEN environment variable from examples

### DIFF
--- a/examples/deckgl-overlay/webpack.config.js
+++ b/examples/deckgl-overlay/webpack.config.js
@@ -49,7 +49,7 @@ const config = {
 
   // Allow setting mapbox token using environment variables
   plugins: [
-    new webpack.EnvironmentPlugin(['MAPBOX_ACCESS_TOKEN', 'MapboxAccessToken']),
+    new webpack.EnvironmentPlugin(['MapboxAccessToken']),
     new webpack.LoaderOptionsPlugin({minimize: false, debug: true})
   ]
 };

--- a/examples/exhibit-browserify/app.js
+++ b/examples/exhibit-browserify/app.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import {render} from 'react-dom';
 import MapGL from 'react-map-gl';
 
-const token = process.env.MAPBOX_ACCESS_TOKEN; // eslint-disable-line
+const token = process.env.MapboxAccessToken; // eslint-disable-line
 
 if (!token) {
   throw new Error('Please specify a valid mapbox token');

--- a/examples/main/webpack.config.js
+++ b/examples/main/webpack.config.js
@@ -67,7 +67,7 @@ const config = {
 
   // Allow setting mapbox token using environment variables
   plugins: [
-    new webpack.EnvironmentPlugin(['MAPBOX_ACCESS_TOKEN', 'MapboxAccessToken']),
+    new webpack.EnvironmentPlugin(['MapboxAccessToken']),
     new webpack.LoaderOptionsPlugin({minimize: false, debug: true})
   ]
 };

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -32,7 +32,7 @@ const LOCAL_DEVELOPMENT_CONFIG = {
   },
   // Optional: Enables reading mapbox token from environment variable
   plugins: [
-    new webpack.EnvironmentPlugin(['MAPBOX_ACCESS_TOKEN', 'MapboxAccessToken'])
+    new webpack.EnvironmentPlugin(['MapboxAccessToken'])
   ]
 };
 


### PR DESCRIPTION
- Make all examples consistent with documentation (Mapbox Token doc page recommends using `MapboxAccessToken`)
- Remove console warning for `MAPBOX_ACCESS_TOKEN` not supplied