### PR TITLE
Fix Coordinates for Marker example

### DIFF
--- a/docs/components/marker.md
+++ b/docs/components/marker.md
@@ -11,8 +11,8 @@ import ReactMapGL, {Marker} from 'react-map-gl';
 class Map extends Component {
   render() {
     return (
-      <ReactMapGL latitude={-122.41} longitude={37.78} zoom={8}>
-        <Marker latitude={-122.41} longitude={37.78} offsetLeft={-20} offsetTop={-10}>
+      <ReactMapGL latitude={37.78} longitude={-122.41} zoom={8}>
+        <Marker latitude={37.78} longitude={-122.41} offsetLeft={-20} offsetTop={-10}>
           <div>You are here</div>
         </Marker>
       </ReactMapGL>


### PR DESCRIPTION
Switch around the Latitude and Longitude values in the example (for ReactMapGL and Marker). The previous values are not a proper LatLng pair, and PerspectiveMercatorViewport.project() returns NaN values.