### PR TITLE
v2.0.x: Fixed PropTypes and refs for react v16.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "glob": "^7.1.1",
     "global": "^4.3.0",
     "mapbox-gl": "0.32.1",
+    "prop-types": "^15.5.10",
     "pure-render-decorator": "^1.1.0",
     "svg-transform": "0.0.3",
     "viewport-mercator-project": "^2.0.1"

--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -20,7 +20,8 @@
 
 // Portions of the code below originally from:
 // https://github.com/mapbox/mapbox-gl-js/blob/master/js/ui/handler/scroll_zoom.js
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 import document from 'global/document';
 import window from 'global/window';

--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -124,15 +124,16 @@ export default class Interactions extends Component {
       pos: null,
       mouseWheelPos: null
     };
+    this._container = null;
   }
 
   _getMousePos(event) {
-    const el = this.container;
+    const el = this._container;
     return getMousePosition(el, event);
   }
 
   _getTouchPos(event) {
-    const el = this.container;
+    const el = this._container;
     const positions = getTouchPositions(el, event);
     return centroid(positions);
   }
@@ -325,7 +326,7 @@ export default class Interactions extends Component {
 
   @autobind
   _containerRefCallback(container) {
-    this.container = container;
+    this._container = container;
   }
 
   render() {

--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -126,12 +126,12 @@ export default class Interactions extends Component {
   }
 
   _getMousePos(event) {
-    const el = this.refs.container;
+    const el = this.container;
     return getMousePosition(el, event);
   }
 
   _getTouchPos(event) {
-    const el = this.refs.container;
+    const el = this.container;
     const positions = getTouchPositions(el, event);
     return centroid(positions);
   }
@@ -325,7 +325,9 @@ export default class Interactions extends Component {
   render() {
     return (
       <div
-        ref="container"
+        ref={container => {
+          this.container = container;
+        }}
         onMouseMove={ this._onMouseMove }
         onMouseDown={ this._onMouseDown }
         onTouchStart={ this._onTouchStart }

--- a/src/map-interactions.react.js
+++ b/src/map-interactions.react.js
@@ -323,12 +323,15 @@ export default class Interactions extends Component {
     }.bind(this), 200);
   }
 
+  @autobind
+  _containerRefCallback(container) {
+    this.container = container;
+  }
+
   render() {
     return (
       <div
-        ref={container => {
-          this.container = container;
-        }}
+        ref={this._containerRefCallback}
         onMouseMove={ this._onMouseMove }
         onMouseDown={ this._onMouseDown }
         onTouchStart={ this._onTouchStart }

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -668,6 +668,10 @@ export default class MapGL extends Component {
     this._callOnChangeViewport(this._map.transform, {isDragging: false});
   }
 
+  @autobind _mapboxMapRefCallback(mapboxMap) {
+    this.mapboxMap = mapboxMap;
+  }
+
   render() {
     const {className, width, height, style} = this.props;
     const mapStyle = {
@@ -678,9 +682,7 @@ export default class MapGL extends Component {
     };
 
     let content = [
-      <div key="map" ref={mapboxMap => {
-        this.mapboxMap = mapboxMap;
-      }}
+      <div key="map" ref={this._mapboxMapRefCallback}
         style={ mapStyle } className={ className }/>,
       <div key="overlays" className="overlays"
         style={ {position: 'absolute', left: 0, top: 0} }>

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -17,7 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 import pureRender from 'pure-render-decorator';
 

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -253,7 +253,7 @@ export default class MapGL extends Component {
       this.props.mapStyle;
 
     const map = new mapboxgl.Map({
-      container: this.refs.mapboxMap,
+      container: this.mapboxMap,
       center: [this.props.longitude, this.props.latitude],
       zoom: this.props.zoom,
       maxZoom: this.props.maxZoom,
@@ -677,7 +677,9 @@ export default class MapGL extends Component {
     };
 
     let content = [
-      <div key="map" ref="mapboxMap"
+      <div key="map" ref={mapboxMap => {
+        this.mapboxMap = mapboxMap;
+      }}
         style={ mapStyle } className={ className }/>,
       <div key="overlays" className="overlays"
         style={ {position: 'absolute', left: 0, top: 0} }>

--- a/src/map.react.js
+++ b/src/map.react.js
@@ -246,6 +246,7 @@ export default class MapGL extends Component {
       this.componentWillReceiveProps = noop;
       this.componentDidUpdate = noop;
     }
+    this._mapboxMap = null;
   }
 
   componentDidMount() {
@@ -254,7 +255,7 @@ export default class MapGL extends Component {
       this.props.mapStyle;
 
     const map = new mapboxgl.Map({
-      container: this.mapboxMap,
+      container: this._mapboxMap,
       center: [this.props.longitude, this.props.latitude],
       zoom: this.props.zoom,
       maxZoom: this.props.maxZoom,
@@ -669,7 +670,7 @@ export default class MapGL extends Component {
   }
 
   @autobind _mapboxMapRefCallback(mapboxMap) {
-    this.mapboxMap = mapboxMap;
+    this._mapboxMap = mapboxMap;
   }
 
   render() {

--- a/src/overlays/canvas.react.js
+++ b/src/overlays/canvas.react.js
@@ -36,6 +36,11 @@ export default class CanvasOverlay extends Component {
     isDragging: PropTypes.bool.isRequired
   };
 
+  constructor() {
+    super();
+    this._overlay = null;
+  }
+
   componentDidMount() {
     this._redraw();
   }
@@ -46,7 +51,7 @@ export default class CanvasOverlay extends Component {
 
   _redraw() {
     const pixelRatio = window.devicePixelRatio || 1;
-    const canvas = this.overlay;
+    const canvas = this._overlay;
     const ctx = canvas.getContext('2d');
     ctx.save();
     ctx.scale(pixelRatio, pixelRatio);
@@ -63,7 +68,7 @@ export default class CanvasOverlay extends Component {
   }
 
   @autobind _overlayRefCallback(overlay) {
-    this.overlay = overlay;
+    this._overlay = overlay;
   }
 
   render() {

--- a/src/overlays/canvas.react.js
+++ b/src/overlays/canvas.react.js
@@ -20,6 +20,7 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import autobind from 'autobind-decorator';
 import ViewportMercator from 'viewport-mercator-project';
 import window from 'global/window';
 
@@ -61,13 +62,15 @@ export default class CanvasOverlay extends Component {
     ctx.restore();
   }
 
+  @autobind _overlayRefCallback(overlay) {
+    this.overlay = overlay;
+  }
+
   render() {
     const pixelRatio = window.devicePixelRatio || 1;
     return (
       <canvas
-        ref={overlay => {
-          this.overlay = overlay;
-        }}
+        ref={this._overlayRefCallback}
         width={ this.props.width * pixelRatio }
         height={ this.props.height * pixelRatio }
         style={ {

--- a/src/overlays/canvas.react.js
+++ b/src/overlays/canvas.react.js
@@ -18,7 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ViewportMercator from 'viewport-mercator-project';
 import window from 'global/window';
 
@@ -44,7 +45,7 @@ export default class CanvasOverlay extends Component {
 
   _redraw() {
     const pixelRatio = window.devicePixelRatio || 1;
-    const canvas = this.refs.overlay;
+    const canvas = this.overlay;
     const ctx = canvas.getContext('2d');
     ctx.save();
     ctx.scale(pixelRatio, pixelRatio);
@@ -64,7 +65,9 @@ export default class CanvasOverlay extends Component {
     const pixelRatio = window.devicePixelRatio || 1;
     return (
       <canvas
-        ref="overlay"
+        ref={overlay => {
+          this.overlay = overlay;
+        }}
         width={ this.props.width * pixelRatio }
         height={ this.props.height * pixelRatio }
         style={ {

--- a/src/overlays/choropleth.react.js
+++ b/src/overlays/choropleth.react.js
@@ -56,6 +56,11 @@ export default class ChoroplethOverlay extends Component {
     valueAccessor: feature => feature.get('properties').get('value')
   };
 
+  constructor() {
+    super();
+    this._overlay = null;
+  }
+
   componentDidMount() {
     this._redraw();
   }
@@ -66,7 +71,7 @@ export default class ChoroplethOverlay extends Component {
 
   _redraw() {
     const pixelRatio = window.devicePixelRatio;
-    const canvas = this.overlay;
+    const canvas = this._overlay;
     const ctx = canvas.getContext('2d');
     const mercator = ViewportMercator(this.props);
 
@@ -118,7 +123,7 @@ export default class ChoroplethOverlay extends Component {
   }
 
   @autobind _overlayRefCallback(overlay) {
-    this.overlay = overlay;
+    this._overlay = overlay;
   }
 
   render() {

--- a/src/overlays/choropleth.react.js
+++ b/src/overlays/choropleth.react.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import autobind from 'autobind-decorator';
 import ViewportMercator from 'viewport-mercator-project';
 import window from 'global/window';
 import {extent} from 'd3-array';
@@ -116,13 +117,15 @@ export default class ChoroplethOverlay extends Component {
     }
   }
 
+  @autobind _overlayRefCallback(overlay) {
+    this.overlay = overlay;
+  }
+
   render() {
     const pixelRatio = window.devicePixelRatio || 1;
     return (
       <canvas
-        ref={overlay => {
-          this.overlay = overlay;
-        }}
+        ref={this._overlayRefCallback}
         width={ this.props.width * pixelRatio }
         height={ this.props.height * pixelRatio }
         style={ {

--- a/src/overlays/choropleth.react.js
+++ b/src/overlays/choropleth.react.js
@@ -17,7 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ViewportMercator from 'viewport-mercator-project';
 import window from 'global/window';
 import {extent} from 'd3-array';
@@ -64,7 +65,7 @@ export default class ChoroplethOverlay extends Component {
 
   _redraw() {
     const pixelRatio = window.devicePixelRatio;
-    const canvas = this.refs.overlay;
+    const canvas = this.overlay;
     const ctx = canvas.getContext('2d');
     const mercator = ViewportMercator(this.props);
 
@@ -119,7 +120,9 @@ export default class ChoroplethOverlay extends Component {
     const pixelRatio = window.devicePixelRatio || 1;
     return (
       <canvas
-        ref="overlay"
+        ref={overlay => {
+          this.overlay = overlay;
+        }}
         width={ this.props.width * pixelRatio }
         height={ this.props.height * pixelRatio }
         style={ {

--- a/src/overlays/draggable-points.react.js
+++ b/src/overlays/draggable-points.react.js
@@ -18,7 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 
 import Immutable from 'immutable';

--- a/src/overlays/draggable-points.react.js
+++ b/src/overlays/draggable-points.react.js
@@ -106,14 +106,16 @@ export default class DraggablePointsOverlay extends Component {
     this.props.onAddPoint(mercator.unproject(pixel));
   }
 
+  @autobind _overlayRefCallback(overlay) {
+    this.overlay = overlay;
+  }
+
   render() {
     const {points, width, height, isDragging, style} = this.props;
     const mercator = ViewportMercator(this.props);
     return (
       <svg
-        ref={container => {
-          this.container = container;
-        }}
+        ref={this._overlayRefCallback}
         width={ width }
         height={ height }
         style={ {

--- a/src/overlays/draggable-points.react.js
+++ b/src/overlays/draggable-points.react.js
@@ -69,6 +69,7 @@ export default class DraggablePointsOverlay extends Component {
     this.state = {
       draggedPointKey: null
     };
+    this._overlay = null;
   }
 
   @autobind
@@ -107,7 +108,7 @@ export default class DraggablePointsOverlay extends Component {
   }
 
   @autobind _overlayRefCallback(overlay) {
-    this.overlay = overlay;
+    this._overlay = overlay;
   }
 
   render() {

--- a/src/overlays/draggable-points.react.js
+++ b/src/overlays/draggable-points.react.js
@@ -81,7 +81,7 @@ export default class DraggablePointsOverlay extends Component {
   @autobind
   _onDrag(event) {
     event.stopPropagation();
-    const pixel = mouse(this.refs.container, event);
+    const pixel = mouse(this.container, event);
     const mercator = ViewportMercator(this.props);
     const lngLat = mercator.unproject(pixel);
     const key = this.state.draggedPointKey;
@@ -100,7 +100,7 @@ export default class DraggablePointsOverlay extends Component {
   _addPoint(event) {
     event.stopPropagation();
     event.preventDefault();
-    const pixel = mouse(this.refs.container, event);
+    const pixel = mouse(this.container, event);
     const mercator = ViewportMercator(this.props);
     this.props.onAddPoint(mercator.unproject(pixel));
   }
@@ -110,7 +110,9 @@ export default class DraggablePointsOverlay extends Component {
     const mercator = ViewportMercator(this.props);
     return (
       <svg
-        ref="container"
+        ref={container => {
+          this.container = container;
+        }}
         width={ width }
         height={ height }
         style={ {

--- a/src/overlays/html.react.js
+++ b/src/overlays/html.react.js
@@ -18,7 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ViewportMercator from 'viewport-mercator-project';
 
 export default class HTMLOverlay extends Component {
@@ -46,7 +47,9 @@ export default class HTMLOverlay extends Component {
     const {project, unproject} = mercator;
 
     return (
-      <div ref="overlay" style={ style }>
+      <div ref={overlay => {
+        this.overlay = overlay;
+      }} style={ style }>
         { this.props.redraw({width, height, project, unproject, isDragging}) }
       </div>
     );

--- a/src/overlays/html.react.js
+++ b/src/overlays/html.react.js
@@ -20,6 +20,7 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import autobind from 'autobind-decorator';
 import ViewportMercator from 'viewport-mercator-project';
 
 export default class HTMLOverlay extends Component {
@@ -31,6 +32,10 @@ export default class HTMLOverlay extends Component {
     isDragging: PropTypes.bool.isRequired
     // TODO: style
   };
+
+  @autobind _overlayRefCallback(overlay) {
+    this.overlay = overlay;
+  }
 
   render() {
     const {width, height, isDragging} = this.props;
@@ -47,9 +52,7 @@ export default class HTMLOverlay extends Component {
     const {project, unproject} = mercator;
 
     return (
-      <div ref={overlay => {
-        this.overlay = overlay;
-      }} style={ style }>
+      <div ref={this._overlayRefCallback} style={ style }>
         { this.props.redraw({width, height, project, unproject, isDragging}) }
       </div>
     );

--- a/src/overlays/html.react.js
+++ b/src/overlays/html.react.js
@@ -33,8 +33,13 @@ export default class HTMLOverlay extends Component {
     // TODO: style
   };
 
+  constructor() {
+    super();
+    this._overlay = null;
+  }
+
   @autobind _overlayRefCallback(overlay) {
-    this.overlay = overlay;
+    this._overlay = overlay;
   }
 
   render() {

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -74,7 +74,7 @@ export default class ScatterplotOverlay extends Component {
 
     const mercator = ViewportMercator(this.props);
     const pixelRatio = window.devicePixelRatio || 1;
-    const canvas = this.refs.overlay;
+    const canvas = this.overlay;
     const ctx = canvas.getContext('2d');
 
     ctx.save();
@@ -108,7 +108,9 @@ export default class ScatterplotOverlay extends Component {
     const pixelRatio = window.devicePixelRatio || 1;
     return (
       <canvas
-        ref="overlay"
+        ref={overlay => {
+          this.overlay = overlay;
+        }}
         width={ width * pixelRatio }
         height={ height * pixelRatio }
         style={ {

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -20,6 +20,7 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import autobind from 'autobind-decorator';
 import window from 'global/window';
 import Immutable from 'immutable';
 import COMPOSITE_TYPES from 'canvas-composite-types';
@@ -103,15 +104,16 @@ export default class ScatterplotOverlay extends Component {
     ctx.restore();
   }
   /* eslint-enable max-statements */
+  @autobind _overlayRefCallback(overlay) {
+    this.overlay = overlay;
+  }
 
   render() {
     const {width, height, globalOpacity} = this.props;
     const pixelRatio = window.devicePixelRatio || 1;
     return (
       <canvas
-        ref={overlay => {
-          this.overlay = overlay;
-        }}
+        ref={this._overlayRefCallback}
         width={ width * pixelRatio }
         height={ height * pixelRatio }
         style={ {

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -59,6 +59,11 @@ export default class ScatterplotOverlay extends Component {
     compositeOperation: 'source-over'
   };
 
+  constructor() {
+    super();
+    this._overlay = null;
+  }
+
   componentDidMount() {
     this._redraw();
   }
@@ -76,7 +81,7 @@ export default class ScatterplotOverlay extends Component {
 
     const mercator = ViewportMercator(this.props);
     const pixelRatio = window.devicePixelRatio || 1;
-    const canvas = this.overlay;
+    const canvas = this._overlay;
     const ctx = canvas.getContext('2d');
 
     ctx.save();
@@ -105,7 +110,7 @@ export default class ScatterplotOverlay extends Component {
   }
   /* eslint-enable max-statements */
   @autobind _overlayRefCallback(overlay) {
-    this.overlay = overlay;
+    this._overlay = overlay;
   }
 
   render() {

--- a/src/overlays/scatterplot.react.js
+++ b/src/overlays/scatterplot.react.js
@@ -18,7 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import window from 'global/window';
 import Immutable from 'immutable';
 import COMPOSITE_TYPES from 'canvas-composite-types';

--- a/src/overlays/svg.react.js
+++ b/src/overlays/svg.react.js
@@ -20,6 +20,7 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import autobind from 'autobind-decorator';
 import ViewportMercator from 'viewport-mercator-project';
 
 export default class SVGOverlay extends Component {
@@ -33,6 +34,10 @@ export default class SVGOverlay extends Component {
     redraw: PropTypes.func.isRequired,
     isDragging: PropTypes.bool.isRequired
   };
+
+  @autobind _overlayRefCallback(overlay) {
+    this.overlay = overlay;
+  }
 
   render() {
     const {width, height, isDragging} = this.props;
@@ -48,9 +53,7 @@ export default class SVGOverlay extends Component {
 
     return (
       <svg
-        ref={overlay => {
-          this.overlay = overlay;
-        }}
+        ref={this._overlayRefCallback}
         width={ width }
         height={ height }
         style={ style }>

--- a/src/overlays/svg.react.js
+++ b/src/overlays/svg.react.js
@@ -18,7 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ViewportMercator from 'viewport-mercator-project';
 
 export default class SVGOverlay extends Component {
@@ -47,7 +48,9 @@ export default class SVGOverlay extends Component {
 
     return (
       <svg
-        ref="overlay"
+        ref={overlay => {
+          this.overlay = overlay;
+        }}
         width={ width }
         height={ height }
         style={ style }>

--- a/src/overlays/svg.react.js
+++ b/src/overlays/svg.react.js
@@ -35,8 +35,13 @@ export default class SVGOverlay extends Component {
     isDragging: PropTypes.bool.isRequired
   };
 
+  constructor() {
+    super();
+    this._overlay = null;
+  }
+
   @autobind _overlayRefCallback(overlay) {
-    this.overlay = overlay;
+    this._overlay = overlay;
   }
 
   render() {


### PR DESCRIPTION
Hi, this fixes the v2.0 for react version 16 by touching up deprecated APIs. A merge of this would be very helpful to us and It shouldn't be a breaking change in any way.

Thank you for the consideration! (CLA has been signed)