### PR TITLE
Match viewport to Mapbox at low zoom levels

### DIFF
--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -7,6 +7,7 @@ export const MAPBOX_LIMITS = {
   maxZoom: 20,
   minPitch: 0,
   maxPitch: 60,
+  // defined by mapbox-gl
   maxLatitude: 85.05113,
   minLatitude: -85.05113
 };
@@ -302,14 +303,17 @@ export default class MapState {
     let shiftY = 0;
 
     if (bottomY - topY < height) {
+      // Map height must not be smaller than viewport height
       props.zoom += Math.log2(height / (bottomY - topY));
       const newRange = this._getLatitudeRange(props);
       [topY, bottomY] = newRange.latitudeRange;
       viewport = newRange.viewport;
     }
     if (topY > 0) {
+      // Compensate for white gap on top
       shiftY = topY;
     } else if (bottomY < height) {
+      // Compensate for white gap on bottom
       shiftY = bottomY - height;
     }
     if (shiftY) {

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -6,7 +6,9 @@ export const MAPBOX_LIMITS = {
   minZoom: 0,
   maxZoom: 20,
   minPitch: 0,
-  maxPitch: 60
+  maxPitch: 60,
+  maxLatitude: 85.05113,
+  minLatitude: -85.05113
 };
 
 const defaultState = {
@@ -55,6 +57,8 @@ export default class MapState {
     minZoom,
     maxPitch,
     minPitch,
+    maxLatitude,
+    minLatitude,
 
     /** Interaction states, required to calculate change during transform */
     /* The point on map being grabbed when the operation first started */
@@ -86,7 +90,9 @@ export default class MapState {
       maxZoom: ensureFinite(maxZoom, MAPBOX_LIMITS.maxZoom),
       minZoom: ensureFinite(minZoom, MAPBOX_LIMITS.minZoom),
       maxPitch: ensureFinite(maxPitch, MAPBOX_LIMITS.maxPitch),
-      minPitch: ensureFinite(minPitch, MAPBOX_LIMITS.minPitch)
+      minPitch: ensureFinite(minPitch, MAPBOX_LIMITS.minPitch),
+      maxLatitude: ensureFinite(maxLatitude, MAPBOX_LIMITS.maxLatitude),
+      minLatitude: ensureFinite(minLatitude, MAPBOX_LIMITS.minLatitude)
     });
 
     this._interactiveState = {
@@ -290,7 +296,42 @@ export default class MapState {
     props.pitch = pitch > maxPitch ? maxPitch : pitch;
     props.pitch = pitch < minPitch ? minPitch : pitch;
 
+    // Constrain zoom and shift center at low zoom levels
+    const {height} = props;
+    let {latitudeRange: [topY, bottomY], viewport} = this._getLatitudeRange(props);
+    let shiftY = 0;
+
+    if (bottomY - topY < height) {
+      props.zoom += Math.log2(height / (bottomY - topY));
+      const newRange = this._getLatitudeRange(props);
+      [topY, bottomY] = newRange.latitudeRange;
+      viewport = newRange.viewport;
+    }
+    if (topY > 0) {
+      shiftY = topY;
+    } else if (bottomY < height) {
+      shiftY = bottomY - height;
+    }
+    if (shiftY) {
+      props.latitude = viewport.unproject([props.width / 2, height / 2 + shiftY])[1];
+    }
+
     return props;
+  }
+
+  // Returns {viewport, latitudeRange: [topY, bottomY]} in non-perspective mode
+  _getLatitudeRange(props) {
+    const flatViewport = new PerspectiveMercatorViewport(Object.assign({}, props, {
+      pitch: 0,
+      bearing: 0
+    }));
+    return {
+      viewport: flatViewport,
+      latitudeRange: [
+        flatViewport.project([props.longitude, props.maxLatitude])[1],
+        flatViewport.project([props.longitude, props.minLatitude])[1]
+      ]
+    };
   }
 
   _unproject(pos) {

--- a/test/utils/map-state.spec.js
+++ b/test/utils/map-state.spec.js
@@ -17,8 +17,8 @@ const SAMPLE_VIEWPORTS = [
     width: 800,
     height: 600,
     longitude: -179,
-    latitude: 90,
-    zoom: 0,
+    latitude: 75,
+    zoom: 3,
     maxZoom: 0.5
   },
   // SF with rotation, custom pitch limit
@@ -51,6 +51,23 @@ test('MapState - Constructor', t => {
   } catch (error) {
     t.ok(/must be supplied/.test(error.message), 'Should throw error for missing prop');
   }
+
+  t.end();
+});
+
+test('MapState - Low zoom', t => {
+
+  const viewport = new MapState({
+    width: 800,
+    height: 600,
+    longitude: -179,
+    latitude: 80,
+    zoom: 0,
+    maxZoom: 0.5
+  }).getViewportProps();
+
+  t.ok(viewport.zoom > 0, 'Constrained zoom');
+  t.ok(Math.abs(viewport.latitude) < 1e-7, 'Centered map');
 
   t.end();
 });


### PR DESCRIPTION
Fit and re-center map in viewport to avoid empty space around the map.
![screen shot 2017-07-12 at 2 36 54 pm](https://user-images.githubusercontent.com/2059298/28141088-f8a6c2f2-670f-11e7-803b-1fa048c916e4.png)
