### PR TITLE
Update NavigationControl component docs

### DIFF
--- a/docs/components/navigation-control.md
+++ b/docs/components/navigation-control.md
@@ -5,14 +5,15 @@ which provides zoom buttons and a compass button.
 
 ```js
 import {Component} from 'react';
-import ReactMapGL, {Popup} from 'react-map-gl';
+import ReactMapGL, {NavigationControl} from 'react-map-gl';
 
 class Map extends Component {
   render() {
+    const {viewport, updateViewport} = this.props;
     return (
-      <ReactMapGL {...viewport} onChangeViewport={updateViewport}>
+      <ReactMapGL {...viewport} onViewportChange={updateViewport}>
         <div style={{position: 'absolute', right: 0}}>
-          <NavigationControl onChangeViewport={updateViewport} />
+          <NavigationControl onViewportChange={updateViewport} />
         </div>
       </ReactMapGL>
     );


### PR DESCRIPTION
I'm currently using version 3.0.0-beta.3 in a project, and while looking at the docs I fixed a few minor problems in the example code:
- It should import `NavigationControl` and not `Popup`.
- It should use `onViewportChange` and not `onChangeViewport` which is deprecated.
- It should be made clear that `viewport` and `updateViewport` are component props.

Thanks to the maintainers for their great work on this package.