### PR TITLE
Corrects the env variable used

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -3,4 +3,4 @@ This is the source code of the documentation pages for react-map-gl
 ## Developing
 
     npm install
-    export MAPBOX_ACCESS_TOKEN=<insert_your_token> && npm start
+    export MapboxAccessToken=<insert_your_token> && npm start


### PR DESCRIPTION
MapboxAccessToken and not MAPBOX_ACCESS_TOKEN is used.
see https://github.com/uber/react-map-gl/blob/master/website/webpack/config.js#L67