### PR TITLE
Fix scale for map affected by a CSS transform in v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+[TBD]
+
+- FIX: interaction when map is scaled by CSS transform
+
 ## Version 3.0.3 (August 01, 2017)
 
 - `v3.0.2` skipped because of faulty publish

--- a/src/utils/event-manager/event-manager.js
+++ b/src/utils/event-manager/event-manager.js
@@ -184,11 +184,15 @@ export default class EventManager {
         y: srcEvent.clientY
       };
 
-      // Calculate center relative to the root element
       const rect = element.getBoundingClientRect();
+      // Fix scale for map affected by a CSS transform.
+      // See https://stackoverflow.com/a/26893663/3528533
+      const scaleX = rect.width / element.offsetWidth;
+      const scaleY = rect.height / element.offsetHeight;
+      // Calculate center relative to the root element
       const offsetCenter = {
-        x: center.x - rect.left - element.clientLeft,
-        y: center.y - rect.top - element.clientTop
+        x: (center.x - rect.left - element.clientLeft) / scaleX,
+        y: (center.y - rect.top - element.clientTop) / scaleY
       };
 
       handler(Object.assign({}, event, {


### PR DESCRIPTION
**For 3.0-release**

Fix pointer position when the map is scaled by css transform.
Same technique as @nwlieb used in https://github.com/uber/react-map-gl/pull/318