### PR TITLE
Add babel-runtime to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [TBD]
 
+- FIX: missing `babel-runtime` module at runtime
 - FIX: interaction when map is scaled by CSS transform
 
 ## Version 3.0.3 (August 01, 2017)

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
     "publish-beta": "npm run build && npm run test && npm publish --tag beta"
   },
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "bowser": "^1.2.0",
-    "mjolnir.js": ">=0.1.0",
     "immutable": "*",
     "mapbox-gl": "0.38.0",
+    "mjolnir.js": ">=0.1.0",
     "prop-types": "^15.5.7",
     "viewport-mercator-project": "^4.0.1"
   },


### PR DESCRIPTION
Fix https://github.com/uber/react-map-gl/issues/374 as instructed by [transform-runtime documentation](https://babeljs.io/docs/plugins/transform-runtime/).

This is only required by the transpiled es5 version.
