### PR TITLE
Allow controls and overlays to block map interactions

### DIFF
--- a/docs/components/marker.md
+++ b/docs/components/marker.md
@@ -36,13 +36,13 @@ Offset of the marker from the left in pixels, negative number indicates left.
 Offset of the marker from the top in pixels, negative number indicates up.
 
 ##### `captureScroll` {Boolean} - default: `false`
-Block map zoom when scrolling over this component.
+Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `true`
-Block map pan & rotate when dragging this component.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
 
 ##### `captureClick` {Boolean} - default: `true`
-Block map click when clicking on this component.
+Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.
 
 ##### `captureDoubleClick` {Boolean} - default: `true`
-Block map zoom when double clicking on this component.
+Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.

--- a/docs/components/marker.md
+++ b/docs/components/marker.md
@@ -34,3 +34,15 @@ Offset of the marker from the left in pixels, negative number indicates left.
 
 ##### `offsetTop` {Number} - default: `0`
 Offset of the marker from the top in pixels, negative number indicates up.
+
+##### `preventScrollZoom` {Boolean} - default: `false`
+Block map zoom when scrolling over this component.
+
+##### `preventDragPanRotate` {Boolean} - default: `true`
+Block map pan & rotate when dragging this component.
+
+##### `preventClick` {Boolean} - default: `true`
+Block map click when clicking on this component.
+
+##### `preventDoubleClickZoom` {Boolean} - default: `true`
+Block map zoom when double clicking on this component.

--- a/docs/components/marker.md
+++ b/docs/components/marker.md
@@ -35,14 +35,14 @@ Offset of the marker from the left in pixels, negative number indicates left.
 ##### `offsetTop` {Number} - default: `0`
 Offset of the marker from the top in pixels, negative number indicates up.
 
-##### `preventScrollZoom` {Boolean} - default: `false`
+##### `captureScroll` {Boolean} - default: `false`
 Block map zoom when scrolling over this component.
 
-##### `preventDragPanRotate` {Boolean} - default: `true`
+##### `captureDrag` {Boolean} - default: `true`
 Block map pan & rotate when dragging this component.
 
-##### `preventClick` {Boolean} - default: `true`
+##### `captureClick` {Boolean} - default: `true`
 Block map click when clicking on this component.
 
-##### `preventDoubleClickZoom` {Boolean} - default: `true`
+##### `captureDoubleClick` {Boolean} - default: `true`
 Block map zoom when double clicking on this component.

--- a/docs/components/navigation-control.md
+++ b/docs/components/navigation-control.md
@@ -26,16 +26,16 @@ class Map extends Component {
 ##### `onViewportChange` {Function}
 Callback when the viewport needs to be updated. See [InteractiveMap](/docs/components/interactive-map.md).
 
-##### `preventScrollZoom` {Boolean} - default: `false`
+##### `captureScroll` {Boolean} - default: `false`
 Block map zoom when scrolling over this component.
 
-##### `preventDragPanRotate` {Boolean} - default: `true`
+##### `captureDrag` {Boolean} - default: `true`
 Block map pan & rotate when dragging this component.
 
-##### `preventClick` {Boolean} - default: `true`
+##### `captureClick` {Boolean} - default: `true`
 Block map click when clicking on this component.
 
-##### `preventDoubleClickZoom` {Boolean} - default: `true`
+##### `captureDoubleClick` {Boolean} - default: `true`
 Block map zoom when double clicking on this component.
 
 ## Styling

--- a/docs/components/navigation-control.md
+++ b/docs/components/navigation-control.md
@@ -26,6 +26,18 @@ class Map extends Component {
 ##### `onViewportChange` {Function}
 Callback when the viewport needs to be updated. See [InteractiveMap](/docs/components/interactive-map.md).
 
+##### `preventScrollZoom` {Boolean} - default: `false`
+Block map zoom when scrolling over this component.
+
+##### `preventDragPanRotate` {Boolean} - default: `true`
+Block map pan & rotate when dragging this component.
+
+##### `preventClick` {Boolean} - default: `true`
+Block map click when clicking on this component.
+
+##### `preventDoubleClickZoom` {Boolean} - default: `true`
+Block map zoom when double clicking on this component.
+
 ## Styling
 
 Like its Mapbox counterpart, this control relies on the mapbox-gl stylesheet to work properly.

--- a/docs/components/navigation-control.md
+++ b/docs/components/navigation-control.md
@@ -27,16 +27,16 @@ class Map extends Component {
 Callback when the viewport needs to be updated. See [InteractiveMap](/docs/components/interactive-map.md).
 
 ##### `captureScroll` {Boolean} - default: `false`
-Block map zoom when scrolling over this component.
+Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `true`
-Block map pan & rotate when dragging this component.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
 
 ##### `captureClick` {Boolean} - default: `true`
-Block map click when clicking on this component.
+Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.
 
 ##### `captureDoubleClick` {Boolean} - default: `true`
-Block map zoom when double clicking on this component.
+Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.
 
 ## Styling
 

--- a/docs/components/popup.md
+++ b/docs/components/popup.md
@@ -54,16 +54,16 @@ If `true`, the anchor will be dynamically adjusted to ensure the popup falls wit
 Callback when the user closes the popup.
 
 ##### `captureScroll` {Boolean} - default: `false`
-Block map zoom when scrolling over this component.
+Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `true`
-Block map pan & rotate when dragging this component.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
 
 ##### `captureClick` {Boolean} - default: `true`
-Block map click when clicking on this component.
+Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.
 
 ##### `captureDoubleClick` {Boolean} - default: `true`
-Block map zoom when double clicking on this component.
+Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.
 
 
 ## Styling

--- a/docs/components/popup.md
+++ b/docs/components/popup.md
@@ -53,16 +53,16 @@ If `true`, the anchor will be dynamically adjusted to ensure the popup falls wit
 ##### `onClose` {Function}
 Callback when the user closes the popup.
 
-##### `preventScrollZoom` {Boolean} - default: `false`
+##### `captureScroll` {Boolean} - default: `false`
 Block map zoom when scrolling over this component.
 
-##### `preventDragPanRotate` {Boolean} - default: `true`
+##### `captureDrag` {Boolean} - default: `true`
 Block map pan & rotate when dragging this component.
 
-##### `preventClick` {Boolean} - default: `true`
+##### `captureClick` {Boolean} - default: `true`
 Block map click when clicking on this component.
 
-##### `preventDoubleClickZoom` {Boolean} - default: `true`
+##### `captureDoubleClick` {Boolean} - default: `true`
 Block map zoom when double clicking on this component.
 
 

--- a/docs/components/popup.md
+++ b/docs/components/popup.md
@@ -53,6 +53,19 @@ If `true`, the anchor will be dynamically adjusted to ensure the popup falls wit
 ##### `onClose` {Function}
 Callback when the user closes the popup.
 
+##### `preventScrollZoom` {Boolean} - default: `false`
+Block map zoom when scrolling over this component.
+
+##### `preventDragPanRotate` {Boolean} - default: `true`
+Block map pan & rotate when dragging this component.
+
+##### `preventClick` {Boolean} - default: `true`
+Block map click when clicking on this component.
+
+##### `preventDoubleClickZoom` {Boolean} - default: `true`
+Block map zoom when double clicking on this component.
+
+
 ## Styling
 
 Like its Mapbox counterpart, this control relies on the mapbox-gl stylesheet to work properly.

--- a/docs/overlays/canvas-overlay.md
+++ b/docs/overlays/canvas-overlay.md
@@ -14,3 +14,15 @@ Parameters:
 - `height` {Number} - height of the viewport
 - `project` {Function} - get screen position `[x, y]` from geo coordinates `[lng, lat]`
 - `unproject` {Function} - get geo coordinates `[lng, lat]` from screen position `[x, y]`
+
+##### `preventScrollZoom` {Boolean} - default: `false`
+Block map zoom when scrolling over this component.
+
+##### `preventDragPanRotate` {Boolean} - default: `false`
+Block map pan & rotate when dragging this component.
+
+##### `preventClick` {Boolean} - default: `false`
+Block map click when clicking on this component.
+
+##### `preventDoubleClickZoom` {Boolean} - default: `false`
+Block map zoom when double clicking on this component.

--- a/docs/overlays/canvas-overlay.md
+++ b/docs/overlays/canvas-overlay.md
@@ -15,14 +15,14 @@ Parameters:
 - `project` {Function} - get screen position `[x, y]` from geo coordinates `[lng, lat]`
 - `unproject` {Function} - get geo coordinates `[lng, lat]` from screen position `[x, y]`
 
-##### `preventScrollZoom` {Boolean} - default: `false`
+##### `captureScroll` {Boolean} - default: `false`
 Block map zoom when scrolling over this component.
 
-##### `preventDragPanRotate` {Boolean} - default: `false`
+##### `captureDrag` {Boolean} - default: `false`
 Block map pan & rotate when dragging this component.
 
-##### `preventClick` {Boolean} - default: `false`
+##### `captureClick` {Boolean} - default: `false`
 Block map click when clicking on this component.
 
-##### `preventDoubleClickZoom` {Boolean} - default: `false`
+##### `captureDoubleClick` {Boolean} - default: `false`
 Block map zoom when double clicking on this component.

--- a/docs/overlays/canvas-overlay.md
+++ b/docs/overlays/canvas-overlay.md
@@ -16,13 +16,13 @@ Parameters:
 - `unproject` {Function} - get geo coordinates `[lng, lat]` from screen position `[x, y]`
 
 ##### `captureScroll` {Boolean} - default: `false`
-Block map zoom when scrolling over this component.
+Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `false`
-Block map pan & rotate when dragging this component.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
 
 ##### `captureClick` {Boolean} - default: `false`
-Block map click when clicking on this component.
+Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.
 
 ##### `captureDoubleClick` {Boolean} - default: `false`
-Block map zoom when double clicking on this component.
+Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.

--- a/docs/overlays/custom-overlays.md
+++ b/docs/overlays/custom-overlays.md
@@ -7,18 +7,16 @@ the current viewport through the React [context](https://facebook.github.io/reac
 ```js
 import React from 'react';
 import PropTypes from 'prop-types';
+import {BaseControl} from 'react-map-gl';
 
-class MyCustomOverlay extends React.Component {
+class MyCustomOverlay extends BaseControl {
   render() {
     const {viewport} = this.context;
     // draw something
+    // _onContainerLoad registers event listeners for map interactions
+    return <div ref={this._onContainerLoad} />;
   }
 }
-
-MyCustomOverlay.contextType = {
-  viewport: PropTypes.object,
-  isDragging: PropTypes.bool
-};
 ```
 
 Here's an example of using the [ScatterplotOverlay](https://github.com/uber/react-map-gl/blob/master/examples/additional-overlays/scatterplot-overlay.js):

--- a/docs/overlays/html-overlay.md
+++ b/docs/overlays/html-overlay.md
@@ -18,14 +18,14 @@ Parameters:
 
 Additional css styles of the `div` container.
 
-##### `preventScrollZoom` {Boolean} - default: `false`
+##### `captureScroll` {Boolean} - default: `false`
 Block map zoom when scrolling over this component.
 
-##### `preventDragPanRotate` {Boolean} - default: `false`
+##### `captureDrag` {Boolean} - default: `false`
 Block map pan & rotate when dragging this component.
 
-##### `preventClick` {Boolean} - default: `false`
+##### `captureClick` {Boolean} - default: `false`
 Block map click when clicking on this component.
 
-##### `preventDoubleClickZoom` {Boolean} - default: `false`
+##### `captureDoubleClick` {Boolean} - default: `false`
 Block map zoom when double clicking on this component.

--- a/docs/overlays/html-overlay.md
+++ b/docs/overlays/html-overlay.md
@@ -17,3 +17,15 @@ Parameters:
 ### `style` {Object, optional}
 
 Additional css styles of the `div` container.
+
+##### `preventScrollZoom` {Boolean} - default: `false`
+Block map zoom when scrolling over this component.
+
+##### `preventDragPanRotate` {Boolean} - default: `false`
+Block map pan & rotate when dragging this component.
+
+##### `preventClick` {Boolean} - default: `false`
+Block map click when clicking on this component.
+
+##### `preventDoubleClickZoom` {Boolean} - default: `false`
+Block map zoom when double clicking on this component.

--- a/docs/overlays/html-overlay.md
+++ b/docs/overlays/html-overlay.md
@@ -19,13 +19,13 @@ Parameters:
 Additional css styles of the `div` container.
 
 ##### `captureScroll` {Boolean} - default: `false`
-Block map zoom when scrolling over this component.
+Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `false`
-Block map pan & rotate when dragging this component.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
 
 ##### `captureClick` {Boolean} - default: `false`
-Block map click when clicking on this component.
+Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.
 
 ##### `captureDoubleClick` {Boolean} - default: `false`
-Block map zoom when double clicking on this component.
+Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.

--- a/docs/overlays/svg-overlay.md
+++ b/docs/overlays/svg-overlay.md
@@ -19,13 +19,13 @@ Parameters:
 Additional css styles of the `svg` container.
 
 ##### `captureScroll` {Boolean} - default: `false`
-Block map zoom when scrolling over this component.
+Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `false`
-Block map pan & rotate when dragging this component.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
 
 ##### `captureClick` {Boolean} - default: `false`
-Block map click when clicking on this component.
+Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.
 
 ##### `captureDoubleClick` {Boolean} - default: `false`
-Block map zoom when double clicking on this component.
+Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.

--- a/docs/overlays/svg-overlay.md
+++ b/docs/overlays/svg-overlay.md
@@ -18,14 +18,14 @@ Parameters:
 
 Additional css styles of the `svg` container.
 
-##### `preventScrollZoom` {Boolean} - default: `false`
+##### `captureScroll` {Boolean} - default: `false`
 Block map zoom when scrolling over this component.
 
-##### `preventDragPanRotate` {Boolean} - default: `false`
+##### `captureDrag` {Boolean} - default: `false`
 Block map pan & rotate when dragging this component.
 
-##### `preventClick` {Boolean} - default: `false`
+##### `captureClick` {Boolean} - default: `false`
 Block map click when clicking on this component.
 
-##### `preventDoubleClickZoom` {Boolean} - default: `false`
+##### `captureDoubleClick` {Boolean} - default: `false`
 Block map zoom when double clicking on this component.

--- a/docs/overlays/svg-overlay.md
+++ b/docs/overlays/svg-overlay.md
@@ -17,3 +17,15 @@ Parameters:
 ### `style` {Object, optional}
 
 Additional css styles of the `svg` container.
+
+##### `preventScrollZoom` {Boolean} - default: `false`
+Block map zoom when scrolling over this component.
+
+##### `preventDragPanRotate` {Boolean} - default: `false`
+Block map pan & rotate when dragging this component.
+
+##### `preventClick` {Boolean} - default: `false`
+Block map click when clicking on this component.
+
+##### `preventDoubleClickZoom` {Boolean} - default: `false`
+Block map zoom when double clicking on this component.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "bowser": "^1.2.0",
     "immutable": "*",
     "mapbox-gl": "0.40.1",
-    "mjolnir.js": ">=0.1.0",
+    "mjolnir.js": ">=0.2.0",
     "prop-types": "^15.5.7",
     "viewport-mercator-project": "^4.0.1"
   },

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import {Component} from 'react';
+import PropTypes from 'prop-types';
+import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+
+const stopPropagation = event => event.stopPropagation();
+
+const propTypes = {
+  /** Event handling */
+  onWheel: PropTypes.func,
+  // Stop map pan & rotate
+  onDragStart: PropTypes.func,
+  // Stop map click
+  onClick: PropTypes.func,
+  // Stop map double click
+  onDblClick: PropTypes.func
+};
+
+const defaultProps = {
+  onWheel: null,
+  onDragStart: stopPropagation,
+  onClick: stopPropagation,
+  onDblClick: stopPropagation
+};
+
+const contextTypes = {
+  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
+  eventManager: PropTypes.object
+};
+
+/*
+ * PureComponent doesn't update when context changes.
+ * The only way is to implement our own shouldComponentUpdate here. Considering
+ * the parent component (StaticMap or InteractiveMap) is pure, and map re-render
+ * is almost always triggered by a viewport change, we almost definitely need to
+ * recalculate the marker's position when the parent re-renders.
+ */
+export default class BaseControl extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this._onContainerLoad = this._onContainerLoad.bind(this);
+    this._onEvent = this._onEvent.bind(this);
+  }
+
+  _onContainerLoad(ref) {
+    const events = {
+      wheel: this._onEvent,
+      panstart: this._onEvent,
+      tap: this._onEvent,
+      doubletap: this._onEvent
+    };
+
+    if (ref) {
+      this.context.eventManager.on(events, ref);
+    } else {
+      this.context.eventManager.off(events);
+    }
+  }
+
+  _onEvent(event) {
+    let handler;
+    switch (event.type) {
+    case 'wheel':
+      handler = this.props.onWheel;
+      break;
+    case 'panstart':
+      handler = this.props.onDragStart;
+      break;
+    case 'tap':
+      handler = this.props.onClick;
+      break;
+    case 'doubletap':
+      handler = this.props.onDblClick;
+      break;
+    default:
+    }
+
+    if (handler) {
+      handler(event);
+    }
+  }
+
+  render() {
+    return null;
+  }
+
+}
+
+BaseControl.propTypes = propTypes;
+BaseControl.defaultProps = defaultProps;
+BaseControl.contextTypes = contextTypes;

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -21,28 +21,27 @@ import {Component} from 'react';
 import PropTypes from 'prop-types';
 import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 
-const stopPropagation = event => event.stopPropagation();
-
 const propTypes = {
   /** Event handling */
-  onWheel: PropTypes.func,
+  preventScrollZoom: PropTypes.bool,
   // Stop map pan & rotate
-  onDragStart: PropTypes.func,
+  preventDragPanRotate: PropTypes.bool,
   // Stop map click
-  onClick: PropTypes.func,
+  preventClick: PropTypes.bool,
   // Stop map double click
-  onDblClick: PropTypes.func
+  preventDoubleClickZoom: PropTypes.bool
 };
 
 const defaultProps = {
-  onWheel: null,
-  onDragStart: stopPropagation,
-  onClick: stopPropagation,
-  onDblClick: stopPropagation
+  preventScrollZoom: false,
+  preventDragPanRotate: true,
+  preventClick: true,
+  preventDoubleClickZoom: true
 };
 
 const contextTypes = {
   viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
+  isDragging: PropTypes.bool,
   eventManager: PropTypes.object
 };
 
@@ -66,8 +65,8 @@ export default class BaseControl extends Component {
     const events = {
       wheel: this._onEvent,
       panstart: this._onEvent,
-      tap: this._onEvent,
-      doubletap: this._onEvent
+      click: this._onEvent,
+      dblclick: this._onEvent
     };
 
     if (ref) {
@@ -78,25 +77,25 @@ export default class BaseControl extends Component {
   }
 
   _onEvent(event) {
-    let handler;
+    let stopPropagation;
     switch (event.type) {
     case 'wheel':
-      handler = this.props.onWheel;
+      stopPropagation = this.props.preventScrollZoom;
       break;
     case 'panstart':
-      handler = this.props.onDragStart;
+      stopPropagation = this.props.preventDragPanRotate;
       break;
-    case 'tap':
-      handler = this.props.onClick;
+    case 'click':
+      stopPropagation = this.props.preventClick;
       break;
-    case 'doubletap':
-      handler = this.props.onDblClick;
+    case 'dblclick':
+      stopPropagation = this.props.preventDoubleClickZoom;
       break;
     default:
     }
 
-    if (handler) {
-      handler(event);
+    if (stopPropagation) {
+      event.stopPropagation();
     }
   }
 

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -23,20 +23,20 @@ import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 
 const propTypes = {
   /** Event handling */
-  preventScrollZoom: PropTypes.bool,
+  captureScroll: PropTypes.bool,
   // Stop map pan & rotate
-  preventDragPanRotate: PropTypes.bool,
+  captureDrag: PropTypes.bool,
   // Stop map click
-  preventClick: PropTypes.bool,
+  captureClick: PropTypes.bool,
   // Stop map double click
-  preventDoubleClickZoom: PropTypes.bool
+  captureDoubleClick: PropTypes.bool
 };
 
 const defaultProps = {
-  preventScrollZoom: false,
-  preventDragPanRotate: true,
-  preventClick: true,
-  preventDoubleClickZoom: true
+  captureScroll: false,
+  captureDrag: true,
+  captureClick: true,
+  captureDoubleClick: true
 };
 
 const contextTypes = {
@@ -80,16 +80,16 @@ export default class BaseControl extends Component {
     let stopPropagation;
     switch (event.type) {
     case 'wheel':
-      stopPropagation = this.props.preventScrollZoom;
+      stopPropagation = this.props.captureScroll;
       break;
     case 'panstart':
-      stopPropagation = this.props.preventDragPanRotate;
+      stopPropagation = this.props.captureDrag;
       break;
     case 'click':
-      stopPropagation = this.props.preventClick;
+      stopPropagation = this.props.captureClick;
       break;
     case 'dblclick':
-      stopPropagation = this.props.preventDoubleClickZoom;
+      stopPropagation = this.props.captureDoubleClick;
       break;
     default:
     }

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -117,7 +117,8 @@ const defaultProps = Object.assign({}, StaticMap.defaultProps, MAPBOX_LIMITS, {
 
 const childContextTypes = {
   viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
-  isDragging: PropTypes.bool
+  isDragging: PropTypes.bool,
+  eventManager: PropTypes.object
 };
 
 export default class InteractiveMap extends PureComponent {
@@ -147,7 +148,8 @@ export default class InteractiveMap extends PureComponent {
   getChildContext() {
     return {
       viewport: new PerspectiveMercatorViewport(this.props),
-      isDragging: this.state.isDragging
+      isDragging: this.state.isDragging,
+      eventManager: this._eventManager
     };
   }
 
@@ -288,7 +290,8 @@ export default class InteractiveMap extends PureComponent {
       },
         createElement(StaticMap, Object.assign({}, this.props, {
           visible: this.checkVisibilityConstraints(this.props),
-          ref: this._staticMapLoaded
+          ref: this._staticMapLoaded,
+          children: this._eventManager ? this.props.children : null
         }))
       )
     );

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -17,11 +17,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {Component, createElement} from 'react';
+import {createElement} from 'react';
 import PropTypes from 'prop-types';
-import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import BaseControl from './base-control';
 
-const propTypes = {
+const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Longitude of the anchor point
   longitude: PropTypes.number.isRequired,
   // Latitude of the anchor point
@@ -30,16 +30,12 @@ const propTypes = {
   offsetLeft: PropTypes.number,
   // Offset from the top
   offsetTop: PropTypes.number
-};
+});
 
-const defaultProps = {
+const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   offsetLeft: 0,
   offsetTop: 0
-};
-
-const contextTypes = {
-  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
-};
+});
 
 /*
  * PureComponent doesn't update when context changes.
@@ -48,7 +44,7 @@ const contextTypes = {
  * is almost always triggered by a viewport change, we almost definitely need to
  * recalculate the marker's position when the parent re-renders.
  */
-export default class Marker extends Component {
+export default class Marker extends BaseControl {
 
   render() {
     const {longitude, latitude, offsetLeft, offsetTop} = this.props;
@@ -62,6 +58,7 @@ export default class Marker extends Component {
 
     return createElement('div', {
       className: 'mapboxgl-marker',
+      ref: this._onContainerLoad,
       style: containerStyle,
       children: this.props.children
     });
@@ -72,4 +69,3 @@ export default class Marker extends Component {
 Marker.displayName = 'Marker';
 Marker.propTypes = propTypes;
 Marker.defaultProps = defaultProps;
-Marker.contextTypes = contextTypes;

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -1,34 +1,30 @@
-import {Component, createElement} from 'react';
+import {createElement} from 'react';
 import PropTypes from 'prop-types';
+import BaseControl from './base-control';
 import autobind from '../utils/autobind';
 
-import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 import MapState from '../utils/map-state';
 
 import deprecateWarn from '../utils/deprecate-warn';
 
-const propTypes = {
+const propTypes = Object.assign({}, BaseControl.propTypes, {
   /**
     * `onViewportChange` callback is fired when the user interacted with the
     * map. The object passed to the callback contains `latitude`,
     * `longitude` and `zoom` and additional state information.
     */
   onViewportChange: PropTypes.func.isRequired
-};
+});
 
-const defaultProps = {
+const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   onViewportChange: () => {}
-};
-
-const contextTypes = {
-  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
-};
+});
 
 /*
  * PureComponent doesn't update when context changes, so
  * implementing our own shouldComponentUpdate here.
  */
-export default class NavigationControl extends Component {
+export default class NavigationControl extends BaseControl {
 
   constructor(props) {
     super(props);
@@ -82,7 +78,8 @@ export default class NavigationControl extends Component {
 
   render() {
     return createElement('div', {
-      className: 'mapboxgl-ctrl mapboxgl-ctrl-group'
+      className: 'mapboxgl-ctrl mapboxgl-ctrl-group',
+      ref: this._onContainerLoad
     }, [
       this._renderButton('zoom-in', 'Zoom In', this._onZoomIn),
       this._renderButton('zoom-out', 'Zoom Out', this._onZoomOut),
@@ -94,4 +91,3 @@ export default class NavigationControl extends Component {
 NavigationControl.displayName = 'NavigationControl';
 NavigationControl.propTypes = propTypes;
 NavigationControl.defaultProps = defaultProps;
-NavigationControl.contextTypes = contextTypes;

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -17,14 +17,14 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {Component, createElement} from 'react';
+import {createElement} from 'react';
 import PropTypes from 'prop-types';
-import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import BaseControl from './base-control';
 import autobind from '../utils/autobind';
 
 import {getDynamicPosition, ANCHOR_POSITION} from '../utils/dynamic-position';
 
-const propTypes = {
+const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Longitude of the anchor point
   longitude: PropTypes.number.isRequired,
   // Latitude of the anchor point
@@ -45,9 +45,9 @@ const propTypes = {
   dynamicPosition: PropTypes.bool,
   // Callback when component is closed
   onClose: PropTypes.func
-};
+});
 
-const defaultProps = {
+const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   offsetLeft: 0,
   offsetTop: 0,
   tipSize: 10,
@@ -56,11 +56,7 @@ const defaultProps = {
   closeButton: true,
   closeOnClick: true,
   onClose: () => {}
-};
-
-const contextTypes = {
-  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport)
-};
+});
 
 /*
  * PureComponent doesn't update when context changes.
@@ -69,7 +65,7 @@ const contextTypes = {
  * is almost always triggered by a viewport change, we almost definitely need to
  * recalculate the popup's position when the parent re-renders.
  */
-export default class Popup extends Component {
+export default class Popup extends BaseControl {
 
   constructor(props) {
     super(props);
@@ -152,6 +148,7 @@ export default class Popup extends Component {
     return createElement('div', {
       className: `mapboxgl-popup mapboxgl-popup-anchor-${positionType}`,
       style: containerStyle,
+      ref: this._onContainerLoad,
       onClick: closeOnClick ? this._onClose : null
     }, [
       this._renderTip(),
@@ -164,4 +161,3 @@ export default class Popup extends Component {
 Popup.displayName = 'Popup';
 Popup.propTypes = propTypes;
 Popup.defaultProps = defaultProps;
-Popup.contextTypes = contextTypes;

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ export {default as InteractiveMap} from './components/interactive-map';
 export {default as StaticMap} from './components/static-map';
 
 // React Controls
+export {default as BaseControl} from './components/base-control';
 export {default as Marker} from './components/marker';
 export {default as Popup} from './components/popup';
 export {default as NavigationControl} from './components/navigation-control';

--- a/src/overlays/canvas-overlay.js
+++ b/src/overlays/canvas-overlay.js
@@ -18,22 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Component, createElement} from 'react';
+import {createElement} from 'react';
 import PropTypes from 'prop-types';
-import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import BaseControl from '../components/base-control';
 import {window} from '../utils/globals';
 import autobind from '../utils/autobind';
 
-const propTypes = {
+const propTypes = Object.assign({}, BaseControl.propTypes, {
   redraw: PropTypes.func.isRequired
+});
+
+const defaultProps = {
+  preventScrollZoom: false,
+  preventDragPanRotate: false,
+  preventClick: false,
+  preventDoubleClickZoom: false
 };
 
-const contextTypes = {
-  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
-  isDragging: PropTypes.bool
-};
-
-export default class CanvasOverlay extends Component {
+export default class CanvasOverlay extends BaseControl {
   constructor(props) {
     super(props);
     autobind(this);
@@ -69,6 +71,7 @@ export default class CanvasOverlay extends Component {
 
   _canvasLoaded(ref) {
     this._canvas = ref;
+    this._onContainerLoad(ref);
   }
 
   render() {
@@ -95,4 +98,4 @@ export default class CanvasOverlay extends Component {
 
 CanvasOverlay.displayName = 'CanvasOverlay';
 CanvasOverlay.propTypes = propTypes;
-CanvasOverlay.contextTypes = contextTypes;
+CanvasOverlay.defaultProps = defaultProps;

--- a/src/overlays/canvas-overlay.js
+++ b/src/overlays/canvas-overlay.js
@@ -29,10 +29,10 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 });
 
 const defaultProps = {
-  preventScrollZoom: false,
-  preventDragPanRotate: false,
-  preventClick: false,
-  preventDoubleClickZoom: false
+  captureScroll: false,
+  captureDrag: false,
+  captureClick: false,
+  captureDoubleClick: false
 };
 
 export default class CanvasOverlay extends BaseControl {

--- a/src/overlays/html-overlay.js
+++ b/src/overlays/html-overlay.js
@@ -18,21 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Component, createElement} from 'react';
+import {createElement} from 'react';
 import PropTypes from 'prop-types';
-import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import BaseControl from '../components/base-control';
 
-const propTypes = {
+const propTypes = Object.assign({}, BaseControl.propTypes, {
   redraw: PropTypes.func.isRequired,
   style: PropTypes.object
+});
+
+const defaultProps = {
+  preventScrollZoom: false,
+  preventDragPanRotate: false,
+  preventClick: false,
+  preventDoubleClickZoom: false
 };
 
-const contextTypes = {
-  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
-  isDragging: PropTypes.bool
-};
-
-export default class HTMLOverlay extends Component {
+export default class HTMLOverlay extends BaseControl {
   render() {
     const {viewport, isDragging} = this.context;
     const style = Object.assign({
@@ -46,6 +48,7 @@ export default class HTMLOverlay extends Component {
 
     return (
       createElement('div', {
+        ref: this._onContainerLoad,
         style
       },
         this.props.redraw({
@@ -62,4 +65,4 @@ export default class HTMLOverlay extends Component {
 
 HTMLOverlay.displayName = 'HTMLOverlay';
 HTMLOverlay.propTypes = propTypes;
-HTMLOverlay.contextTypes = contextTypes;
+HTMLOverlay.defaultProps = defaultProps;

--- a/src/overlays/html-overlay.js
+++ b/src/overlays/html-overlay.js
@@ -28,10 +28,10 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 });
 
 const defaultProps = {
-  preventScrollZoom: false,
-  preventDragPanRotate: false,
-  preventClick: false,
-  preventDoubleClickZoom: false
+  captureScroll: false,
+  captureDrag: false,
+  captureClick: false,
+  captureDoubleClick: false
 };
 
 export default class HTMLOverlay extends BaseControl {

--- a/src/overlays/svg-overlay.js
+++ b/src/overlays/svg-overlay.js
@@ -18,21 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Component, createElement} from 'react';
+import {createElement} from 'react';
 import PropTypes from 'prop-types';
-import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import BaseControl from '../components/base-control';
 
-const propTypes = {
+const propTypes = Object.assign({}, BaseControl.propTypes, {
   redraw: PropTypes.func.isRequired,
   style: PropTypes.object
+});
+
+const defaultProps = {
+  preventScrollZoom: false,
+  preventDragPanRotate: false,
+  preventClick: false,
+  preventDoubleClickZoom: false
 };
 
-const contextTypes = {
-  viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
-  isDragging: PropTypes.bool
-};
-
-export default class SVGOverlay extends Component {
+export default class SVGOverlay extends BaseControl {
   render() {
     const {viewport, isDragging} = this.context;
     const style = Object.assign({
@@ -46,6 +48,7 @@ export default class SVGOverlay extends Component {
       createElement('svg', {
         width: viewport.width,
         height: viewport.height,
+        ref: this._onContainerLoad,
         style
       },
         this.props.redraw({
@@ -62,4 +65,4 @@ export default class SVGOverlay extends Component {
 
 SVGOverlay.displayName = 'SVGOverlay';
 SVGOverlay.propTypes = propTypes;
-SVGOverlay.contextTypes = contextTypes;
+SVGOverlay.defaultProps = defaultProps;

--- a/src/overlays/svg-overlay.js
+++ b/src/overlays/svg-overlay.js
@@ -28,10 +28,10 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 });
 
 const defaultProps = {
-  preventScrollZoom: false,
-  preventDragPanRotate: false,
-  preventClick: false,
-  preventDoubleClickZoom: false
+  captureScroll: false,
+  captureDrag: false,
+  captureClick: false,
+  captureDoubleClick: false
 };
 
 export default class SVGOverlay extends BaseControl {

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -134,9 +134,9 @@ export default class MapState {
   pan({pos, startPos}) {
     const startPanLngLat = this._interactiveState.startPanLngLat || this._unproject(startPos);
 
-    // take the start lnglat and put it where the mouse is down.
-    assert(startPanLngLat, '`startPanLngLat` prop is required ' +
-      'for mouse pan behavior to calculate where to position the map.');
+    if (!startPanLngLat) {
+      return this;
+    }
 
     const [longitude, latitude] = this._calculateNewLngLat({startPanLngLat, pos});
 

--- a/test/utils/map-state.spec.js
+++ b/test/utils/map-state.spec.js
@@ -109,12 +109,8 @@ test('MapState - Pan', t => {
   });
 
   // insufficient arguments
-  try {
-    new MapState(SAMPLE_VIEWPORTS[0]).pan({pos: POS_START});
-    t.fail('Should throw error for missing argument');
-  } catch (error) {
-    t.ok(/startPanLngLat/.test(error.message), 'Should throw error for missing argument');
-  }
+  const viewport = new MapState(SAMPLE_VIEWPORTS[0]);
+  t.is(viewport, viewport.pan({pos: POS_START}), 'Do nothing when missing argument');
 
   t.end();
 });


### PR DESCRIPTION
Attempting to tackle problem raised in issues such as https://github.com/uber/react-map-gl/issues/304 https://github.com/uber/react-map-gl/issues/195

Adds the following props to `Marker`, `Popup`, `NavigationControl` and overlay components:
- `captureScroll` {Boolean}
- `captureDrag` {Boolean}
- `captureClick` {Boolean}
- `captureDoubleClick` {Boolean}
