### PR TITLE
Extend control elements with custom classNames

### DIFF
--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -53,6 +53,8 @@ export default class Marker extends Component {
   render() {
     const {longitude, latitude, offsetLeft, offsetTop} = this.props;
 
+    let className = this.props.className || '';
+
     const [x, y] = this.context.viewport.project([longitude, latitude]);
     const containerStyle = {
       position: 'absolute',
@@ -61,7 +63,7 @@ export default class Marker extends Component {
     };
 
     return createElement('div', {
-      className: 'mapboxgl-marker',
+      className: `mapboxgl-marker ${className}`,
       style: containerStyle,
       children: this.props.children
     });

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -33,6 +33,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  className: '',
   offsetLeft: 0,
   offsetTop: 0
 };
@@ -51,9 +52,7 @@ const contextTypes = {
 export default class Marker extends Component {
 
   render() {
-    const {longitude, latitude, offsetLeft, offsetTop} = this.props;
-
-    let className = this.props.className || '';
+    const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
 
     const [x, y] = this.context.viewport.project([longitude, latitude]);
     const containerStyle = {

--- a/src/components/marker.md
+++ b/src/components/marker.md
@@ -1,0 +1,2 @@
+ ##### `className` {String} - default: ``
+  Allows to put custom className with **mapboxgl-marker**

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -79,7 +79,7 @@ export default class NavigationControl extends BaseControl {
 
   render() {
 
-    const { className } = this.props;
+    const {className} = this.props;
 
     return createElement('div', {
       className: `mapboxgl-ctrl mapboxgl-ctrl-group ${className}`,

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -81,8 +81,11 @@ export default class NavigationControl extends Component {
   }
 
   render() {
+
+    let className = this.props.className || '';
+
     return createElement('div', {
-      className: 'mapboxgl-ctrl mapboxgl-ctrl-group'
+      className: `mapboxgl-ctrl mapboxgl-ctrl-group ${className}`
     }, [
       this._renderButton('zoom-in', 'Zoom In', this._onZoomIn),
       this._renderButton('zoom-out', 'Zoom Out', this._onZoomOut),

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -17,6 +17,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  className: '',
   onViewportChange: () => {}
 };
 
@@ -82,7 +83,7 @@ export default class NavigationControl extends Component {
 
   render() {
 
-    let className = this.props.className || '';
+    const { className } = this.props;
 
     return createElement('div', {
       className: `mapboxgl-ctrl mapboxgl-ctrl-group ${className}`

--- a/src/components/navigation-control.md
+++ b/src/components/navigation-control.md
@@ -1,0 +1,2 @@
+ ##### `className` {String} - default: ``
+  Allows to put custom className with **mapboxgl-ctrl mapboxgl-ctrl-group**

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -25,6 +25,8 @@ import autobind from '../utils/autobind';
 import {getDynamicPosition, ANCHOR_POSITION} from '../utils/dynamic-position';
 
 const propTypes = {
+  // Custom className
+  className: '',
   // Longitude of the anchor point
   longitude: PropTypes.number.isRequired,
   // Latitude of the anchor point
@@ -135,9 +137,7 @@ export default class Popup extends Component {
   }
 
   render() {
-    const {longitude, latitude, offsetLeft, offsetTop, closeOnClick} = this.props;
-
-    let className = this.props.className || '';
+    const {className, longitude, latitude, offsetLeft, offsetTop, closeOnClick} = this.props;
 
     const [x, y] = this.context.viewport.project([longitude, latitude]);
 

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -137,6 +137,8 @@ export default class Popup extends Component {
   render() {
     const {longitude, latitude, offsetLeft, offsetTop, closeOnClick} = this.props;
 
+    let className = this.props.className || '';
+
     const [x, y] = this.context.viewport.project([longitude, latitude]);
 
     const positionType = this._getPosition(x, y);
@@ -150,7 +152,7 @@ export default class Popup extends Component {
     };
 
     return createElement('div', {
-      className: `mapboxgl-popup mapboxgl-popup-anchor-${positionType}`,
+      className: `mapboxgl-popup mapboxgl-popup-anchor-${positionType} ${className}`,
       style: containerStyle,
       onClick: closeOnClick ? this._onClose : null
     }, [

--- a/src/components/popup.md
+++ b/src/components/popup.md
@@ -1,0 +1,2 @@
+ ##### `className` {String} - default: ``
+  Allows to put custom className with **mapboxgl-popup mapboxgl-popup-anchor-_${positionType}_**


### PR DESCRIPTION
Re-opened [#376](https://github.com/uber/react-map-gl/pull/376)

Added extended prop `className` for:
* `Marker`
* `Popup`
* `NavigationControl`