### PR TITLE
Port TransitionManager from deck.gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "bowser": "^1.2.0",
     "immutable": "*",
     "mapbox-gl": "0.40.1",
+    "math.gl": ">= 1.0.0-alpha.8",
     "mjolnir.js": ">=0.4.0",
     "prop-types": "^15.5.7",
-    "viewport-mercator-project": "^4.0.1"
+    "viewport-mercator-project": ">= 4.2.0-alpha.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -313,7 +313,7 @@ export default class InteractiveMap extends PureComponent {
         style: eventCanvasStyle
       },
         createElement(StaticMap, Object.assign({}, this.props,
-          this._transitionManger && this._transitionManger.getTransionedViewport(),
+          this._transitionManger && this._transitionManger.getViewportInTransition(),
           {
             visible: this._checkVisibilityConstraints(this.props),
             ref: this._staticMapLoaded,

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -6,6 +6,8 @@ import StaticMap from './static-map';
 import {MAPBOX_LIMITS} from '../utils/map-state';
 import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
 
+import TransitionManager from '../utils/transition-manager';
+
 import {EventManager} from 'mjolnir.js';
 import MapControls from '../utils/map-controls';
 import config from '../config';
@@ -30,6 +32,20 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
    * such as `longitude`, `latitude`, `zoom` etc.
    */
   onViewportChange: PropTypes.func,
+
+  /** Viewport transition **/
+  // transition duration for viewport change
+  transitionDuration: PropTypes.number,
+  // function called for each transition step, can be used to perform custom transitions.
+  transitionInterpolator: PropTypes.func,
+  // type of interruption of current transition on update.
+  transitionInterruption: PropTypes.number,
+  // easing function
+  transitionEasing: PropTypes.func,
+  // transition status update functions
+  onTransitionStart: PropTypes.func,
+  onTransitionInterrupt: PropTypes.func,
+  onTransitionEnd: PropTypes.func,
 
   /** Enables control event handling */
   // Scroll to zoom
@@ -100,22 +116,25 @@ const getDefaultCursor = ({isDragging, isHovering}) => isDragging ?
   config.CURSOR.GRABBING :
   (isHovering ? config.CURSOR.POINTER : config.CURSOR.GRAB);
 
-const defaultProps = Object.assign({}, StaticMap.defaultProps, MAPBOX_LIMITS, {
-  onViewportChange: null,
-  onClick: null,
-  onHover: null,
+const defaultProps = Object.assign({},
+  StaticMap.defaultProps, MAPBOX_LIMITS, TransitionManager.defaultProps,
+  {
+    onViewportChange: null,
+    onClick: null,
+    onHover: null,
 
-  scrollZoom: true,
-  dragPan: true,
-  dragRotate: true,
-  doubleClickZoom: true,
-  touchZoomRotate: true,
+    scrollZoom: true,
+    dragPan: true,
+    dragRotate: true,
+    doubleClickZoom: true,
+    touchZoomRotate: true,
 
-  clickRadius: 0,
-  getCursor: getDefaultCursor,
+    clickRadius: 0,
+    getCursor: getDefaultCursor,
 
-  visibilityConstraints: MAPBOX_LIMITS
-});
+    visibilityConstraints: MAPBOX_LIMITS
+  }
+);
 
 const childContextTypes = {
   viewport: PropTypes.instanceOf(PerspectiveMercatorViewport),
@@ -139,7 +158,9 @@ export default class InteractiveMap extends PureComponent {
       // Whether the cursor is down
       isDragging: false,
       // Whether the cursor is over a clickable feature
-      isHovering: false
+      isHovering: false,
+      // Transition manager props
+      transition: null
     };
 
     // If props.mapControls is not provided, fallback to default MapControls instance
@@ -167,10 +188,13 @@ export default class InteractiveMap extends PureComponent {
       onStateChange: this._onInteractiveStateChange,
       eventManager
     }));
+
+    this._transitionManger = new TransitionManager(this.props, this._onTransitionUpdate);
   }
 
-  componentWillUpdate(nextProps) {
+  componentWillUpdate(nextProps, nextState) {
     this._mapControls.setOptions(nextProps);
+    this._transitionManger.processViewportChange(nextProps);
   }
 
   componentWillUnmount() {
@@ -189,7 +213,7 @@ export default class InteractiveMap extends PureComponent {
   }
 
   // Checks a visibilityConstraints object to see if the map should be displayed
-  checkVisibilityConstraints(props) {
+  _checkVisibilityConstraints(props) {
     const capitalize = s => s[0].toUpperCase() + s.slice(1);
 
     const {visibilityConstraints} = props;
@@ -208,6 +232,13 @@ export default class InteractiveMap extends PureComponent {
       }
     }
     return true;
+  }
+
+  // Helper methods
+  _onTransitionUpdate(viewport) {
+    if (this.props.onViewportChange) {
+      this.props.onViewportChange(viewport);
+    }
   }
 
   _getFeatures({pos, radius}) {
@@ -290,11 +321,14 @@ export default class InteractiveMap extends PureComponent {
         ref: this._eventCanvasLoaded,
         style: eventCanvasStyle
       },
-        createElement(StaticMap, Object.assign({}, this.props, {
-          visible: this.checkVisibilityConstraints(this.props),
-          ref: this._staticMapLoaded,
-          children: this._eventManager ? this.props.children : null
-        }))
+        createElement(StaticMap, Object.assign({}, this.props,
+          this._transitionManger && this._transitionManger.getTransionedViewport(),
+          {
+            visible: this._checkVisibilityConstraints(this.props),
+            ref: this._staticMapLoaded,
+            children: this._eventManager ? this.props.children : null
+          }
+        ))
       )
     );
   }

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -187,12 +187,12 @@ export default class InteractiveMap extends PureComponent {
       eventManager
     }));
 
-    this._transitionManger = new TransitionManager(this.props);
+    this._transitionManager = new TransitionManager(this.props);
   }
 
   componentWillUpdate(nextProps) {
     this._mapControls.setOptions(nextProps);
-    this._transitionManger.processViewportChange(nextProps);
+    this._transitionManager.processViewportChange(nextProps);
   }
 
   componentWillUnmount() {
@@ -313,7 +313,7 @@ export default class InteractiveMap extends PureComponent {
         style: eventCanvasStyle
       },
         createElement(StaticMap, Object.assign({}, this.props,
-          this._transitionManger && this._transitionManger.getViewportInTransition(),
+          this._transitionManager && this._transitionManager.getViewportInTransition(),
           {
             visible: this._checkVisibilityConstraints(this.props),
             ref: this._staticMapLoaded,

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -158,9 +158,7 @@ export default class InteractiveMap extends PureComponent {
       // Whether the cursor is down
       isDragging: false,
       // Whether the cursor is over a clickable feature
-      isHovering: false,
-      // Transition manager props
-      transition: null
+      isHovering: false
     };
 
     // If props.mapControls is not provided, fallback to default MapControls instance
@@ -189,10 +187,10 @@ export default class InteractiveMap extends PureComponent {
       eventManager
     }));
 
-    this._transitionManger = new TransitionManager(this.props, this._onTransitionUpdate);
+    this._transitionManger = new TransitionManager(this.props);
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  componentWillUpdate(nextProps) {
     this._mapControls.setOptions(nextProps);
     this._transitionManger.processViewportChange(nextProps);
   }
@@ -232,13 +230,6 @@ export default class InteractiveMap extends PureComponent {
       }
     }
     return true;
-  }
-
-  // Helper methods
-  _onTransitionUpdate(viewport) {
-    if (this.props.onViewportChange) {
-      this.props.onViewportChange(viewport);
-    }
   }
 
   _getFeatures({pos, radius}) {

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -47,10 +47,12 @@ export default class NavigationControl extends BaseControl {
 
   _updateViewport(opts) {
     const {viewport} = this.context;
-    const mapState = new MapState(Object.assign({}, viewport, LINEAR_TRANSITION_PROPS, opts));
+    const mapState = new MapState(Object.assign({}, viewport, opts));
     // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
     const onViewportChange = this.props.onChangeViewport || this.props.onViewportChange;
-    onViewportChange(mapState.getViewportProps());
+    const newViewport = Object.assign({}, mapState.getViewportProps(), LINEAR_TRANSITION_PROPS);
+
+    onViewportChange(newViewport);
   }
 
   _onZoomIn() {
@@ -62,7 +64,7 @@ export default class NavigationControl extends BaseControl {
   }
 
   _onResetNorth() {
-    this._updateViewport({bearing: 0});
+    this._updateViewport({bearing: 0, pitch: 0});
   }
 
   _renderCompass() {

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -4,8 +4,13 @@ import BaseControl from './base-control';
 import autobind from '../utils/autobind';
 
 import MapState from '../utils/map-state';
+import TransitionManager from '../utils/transition-manager';
 
 import deprecateWarn from '../utils/deprecate-warn';
+
+const LINEAR_TRANSITION_PROPS = Object.assign({}, TransitionManager.defaultProps, {
+  transitionDuration: 300
+});
 
 const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Custom className
@@ -42,7 +47,7 @@ export default class NavigationControl extends BaseControl {
 
   _updateViewport(opts) {
     const {viewport} = this.context;
-    const mapState = new MapState(Object.assign({}, viewport, opts));
+    const mapState = new MapState(Object.assign({}, viewport, LINEAR_TRANSITION_PROPS, opts));
     // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
     const onViewportChange = this.props.onChangeViewport || this.props.onViewportChange;
     onViewportChange(mapState.getViewportProps());

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,10 @@ export {default as CanvasOverlay} from './overlays/canvas-overlay';
 export {default as HTMLOverlay} from './overlays/html-overlay';
 export {default as SVGOverlay} from './overlays/svg-overlay';
 
+import {TRANSITION_EVENTS} from './utils/transition-manager';
+import {viewportLinearInterpolator, viewportFlyToInterpolator}
+  from './utils/viewport-transition-utils';
+
 // Utilities
 
 // Experimental Features (May change in minor version bumps, use at your own risk)
@@ -42,5 +46,8 @@ import autobind from './utils/autobind';
 
 export const experimental = {
   MapControls,
-  autobind
+  autobind,
+  TRANSITION_EVENTS,
+  viewportLinearInterpolator,
+  viewportFlyToInterpolator
 };

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -18,7 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import MapState from '../utils/map-state';
+import MapState from './map-state';
+import TransitionManager from './transition-manager';
+
+const NO_TRANSITION_PROPS = {
+  transitionDuration: 0
+};
+const LINEAR_TRANSITION_PROPS = Object.assign({}, TransitionManager.defaultProps, {
+  transitionDuration: 300
+});
 
 // EVENT HANDLING PARAMETERS
 const PITCH_MOUSE_THRESHOLD = 5;
@@ -98,9 +106,9 @@ export default class MapControls {
 
   /* Callback util */
   // formats map state and invokes callback function
-  updateViewport(newMapState, extraState = {}) {
+  updateViewport(newMapState, extraProps = {}, extraState = {}) {
     const oldViewport = this.mapState.getViewportProps();
-    const newViewport = newMapState.getViewportProps();
+    const newViewport = Object.assign({}, newMapState.getViewportProps(), extraProps);
 
     if (this.onViewportChange &&
       Object.keys(newViewport).some(key => oldViewport[key] !== newViewport[key])) {
@@ -180,7 +188,7 @@ export default class MapControls {
   _onPanStart(event) {
     const pos = this.getCenter(event);
     const newMapState = this.mapState.panStart({pos}).rotateStart({pos});
-    return this.updateViewport(newMapState, {isDragging: true});
+    return this.updateViewport(newMapState, NO_TRANSITION_PROPS, {isDragging: true});
   }
 
   // Default handler for the `panmove` event.
@@ -192,7 +200,7 @@ export default class MapControls {
   // Default handler for the `panend` event.
   _onPanEnd(event) {
     const newMapState = this.mapState.panEnd().rotateEnd();
-    return this.updateViewport(newMapState, {isDragging: false});
+    return this.updateViewport(newMapState, null, {isDragging: false});
   }
 
   // Default handler for panning to move.
@@ -203,7 +211,7 @@ export default class MapControls {
     }
     const pos = this.getCenter(event);
     const newMapState = this.mapState.pan({pos});
-    return this.updateViewport(newMapState);
+    return this.updateViewport(newMapState, NO_TRANSITION_PROPS, {isDragging: true});
   }
 
   // Default handler for panning to rotate.
@@ -235,7 +243,7 @@ export default class MapControls {
     deltaScaleY = Math.min(1, Math.max(-1, deltaScaleY));
 
     const newMapState = this.mapState.rotate({deltaScaleX, deltaScaleY});
-    return this.updateViewport(newMapState);
+    return this.updateViewport(newMapState, NO_TRANSITION_PROPS, {isDragging: true});
   }
 
   // Default handler for the `wheel` event.
@@ -254,14 +262,14 @@ export default class MapControls {
     }
 
     const newMapState = this.mapState.zoom({pos, scale});
-    return this.updateViewport(newMapState);
+    return this.updateViewport(newMapState, NO_TRANSITION_PROPS);
   }
 
   // Default handler for the `pinchstart` event.
   _onPinchStart(event) {
     const pos = this.getCenter(event);
     const newMapState = this.mapState.zoomStart({pos});
-    return this.updateViewport(newMapState, {isDragging: true});
+    return this.updateViewport(newMapState, NO_TRANSITION_PROPS, {isDragging: true});
   }
 
   // Default handler for the `pinch` event.
@@ -272,13 +280,13 @@ export default class MapControls {
     const pos = this.getCenter(event);
     const {scale} = event;
     const newMapState = this.mapState.zoom({pos, scale});
-    return this.updateViewport(newMapState);
+    return this.updateViewport(newMapState, NO_TRANSITION_PROPS, {isDragging: true});
   }
 
   // Default handler for the `pinchend` event.
   _onPinchEnd(event) {
     const newMapState = this.mapState.zoomEnd();
-    return this.updateViewport(newMapState, {isDragging: false});
+    return this.updateViewport(newMapState, null, {isDragging: false});
   }
 
   // Default handler for the `doubletap` event.
@@ -290,7 +298,7 @@ export default class MapControls {
     const isZoomOut = this.isFunctionKeyPressed(event);
 
     const newMapState = this.mapState.zoom({pos, scale: isZoomOut ? 0.5 : 2});
-    return this.updateViewport(newMapState);
+    return this.updateViewport(newMapState, LINEAR_TRANSITION_PROPS);
   }
 
   /* eslint-disable complexity */
@@ -349,7 +357,7 @@ export default class MapControls {
     default:
       return false;
     }
-    return this.updateViewport(newMapState);
+    return this.updateViewport(newMapState, LINEAR_TRANSITION_PROPS);
   }
   /* eslint-enable complexity */
 }

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -53,6 +53,15 @@ export default class MapState {
     */
     altitude,
 
+    /** Viewport transitions */
+    transitionDuration,
+    // function called for each transition step, can be used to perform custom transitions.
+    transitionInterpolator,
+    // type of interruption of current transition on update.
+    transitionInterruption,
+    // easing function
+    transitionEasing,
+
     /** Viewport constraints */
     maxZoom,
     minZoom,
@@ -85,6 +94,12 @@ export default class MapState {
       latitude,
       longitude,
       zoom,
+
+      transitionDuration,
+      transitionEasing,
+      transitionInterruption,
+      transitionInterpolator,
+
       bearing: ensureFinite(bearing, defaultState.bearing),
       pitch: ensureFinite(pitch, defaultState.pitch),
       altitude: ensureFinite(altitude, defaultState.altitude),
@@ -278,10 +293,16 @@ export default class MapState {
   }
 
   // Apply any constraints (mathematical or defined by _viewportProps) to map state
+  /* eslint-disable complexity */
   _applyConstraints(props) {
     // Normalize degrees
-    props.longitude = mod(props.longitude + 180, 360) - 180;
-    props.bearing = mod(props.bearing + 180, 360) - 180;
+    const {longitude, bearing} = props;
+    if (longitude < -180 || longitude > 180) {
+      props.longitude = mod(longitude + 180, 360) - 180;
+    }
+    if (bearing < -180 || bearing > 180) {
+      props.bearing = mod(bearing + 180, 360) - 180;
+    }
 
     // Ensure zoom is within specified range
     const {maxZoom, minZoom, zoom} = props;
@@ -319,6 +340,7 @@ export default class MapState {
 
     return props;
   }
+  /* eslint-enable complexity */
 
   // Returns {viewport, latitudeRange: [topY, bottomY]} in non-perspective mode
   _getLatitudeRange(props) {

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -53,15 +53,6 @@ export default class MapState {
     */
     altitude,
 
-    /** Viewport transitions */
-    transitionDuration,
-    // function called for each transition step, can be used to perform custom transitions.
-    transitionInterpolator,
-    // type of interruption of current transition on update.
-    transitionInterruption,
-    // easing function
-    transitionEasing,
-
     /** Viewport constraints */
     maxZoom,
     minZoom,
@@ -94,11 +85,6 @@ export default class MapState {
       latitude,
       longitude,
       zoom,
-
-      transitionDuration,
-      transitionEasing,
-      transitionInterruption,
-      transitionInterpolator,
 
       bearing: ensureFinite(bearing, defaultState.bearing),
       pitch: ensureFinite(pitch, defaultState.pitch),

--- a/src/utils/map-state.js
+++ b/src/utils/map-state.js
@@ -85,7 +85,6 @@ export default class MapState {
       latitude,
       longitude,
       zoom,
-
       bearing: ensureFinite(bearing, defaultState.bearing),
       pitch: ensureFinite(pitch, defaultState.pitch),
       altitude: ensureFinite(altitude, defaultState.altitude),

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -163,11 +163,12 @@ export default class TransitionManager {
     t = easing(t);
 
     const viewport = interpolator(startViewport, endViewport, t);
-    this.state.viewport = Object.assign({}, endViewport, viewport);
-    if (this.props.onViewportChange) {
       // Normalize viewport props
-      const mapState = new MapState(Object.assign({}, this.props, viewport));
-      this.props.onViewportChange(mapState.getViewportProps());
+    const mapState = new MapState(Object.assign({}, this.props, viewport));
+    this.state.viewport = mapState.getViewportProps();
+
+    if (this.props.onViewportChange) {
+      this.props.onViewportChange(this.state.viewport);
     }
 
     if (shouldEnd) {

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -1,0 +1,209 @@
+/* global setInterval, clearInterval */
+import assert from 'assert';
+import {
+  viewportLinearInterpolator,
+  extractViewportFrom,
+  VIEWPORT_PROPS
+} from './viewport-transition-utils';
+import MapState from './map-state';
+
+const VIEWPORT_TRANSITION_FREQUENCY = 60; // 60 times per second.
+const VIEWPORT_TRANSITION_EASING_FUNC = t => t;
+
+export const TRANSITION_EVENTS = {
+  BREAK: 1,
+  SNAP_TO_END: 2,
+  IGNORE: 3
+};
+
+const DEFAULT_PROPS = {
+  transitionDuration: 0,
+  transitionInterpolator: viewportLinearInterpolator,
+  transitionEasing: VIEWPORT_TRANSITION_EASING_FUNC,
+  transitionInterruption: TRANSITION_EVENTS.BREAK,
+  onTransitionStart: () => {},
+  onTransitionInterrupt: () => {},
+  onTransitionEnd: () => {}
+};
+
+export default class TransitionManager {
+  constructor(props, onTransitionUpdate) {
+    this.props = props;
+    this.onTransitionUpdate = onTransitionUpdate;
+    this.transitionContext = {
+      time: 0,
+      delta: 0,
+      interval: null,
+      viewport: null,
+      startViewport: null,
+      endViewport: null
+    };
+  }
+
+  // Returns current transitioned viewport.
+  getTransionedViewport() {
+    return this.transitionContext.viewport;
+  }
+
+  // Process the vewiport change, either ignore or trigger a new transiton.
+  processViewportChange(nextProps) {
+    const isTransitionInProgress = this._isTransitionInProgress();
+    const isTransitionEnabled = this._isTransitionEnabled(nextProps);
+
+    // NOTE: Be cautious re-ordering statements in this function.
+    if (!isTransitionEnabled && !isTransitionInProgress ||
+      this._shouldIgnoreViewportChange(nextProps)) {
+      this.props = nextProps;
+      return;
+    }
+
+    if (isTransitionEnabled) {
+      const currentViewport = this.transitionContext.viewport || extractViewportFrom(this.props);
+      const endViewport = this.transitionContext.endViewport;
+
+      const startViewport = this._shouldSnapToEnd() ?
+        (endViewport || currentViewport) :
+        currentViewport;
+
+      this._triggerTransition(startViewport, nextProps);
+
+      if (isTransitionInProgress) {
+        this.props.onTransitionInterrupt();
+      }
+      nextProps.onTransitionStart();
+    } else if (isTransitionInProgress) {
+      this.props.onTransitionInterrupt();
+      this._endTransition();
+    }
+
+    this.props = nextProps;
+  }
+
+  // Helper methods
+
+  /* eslint-disable max-depth */
+  _areViewportsEqual(startViewport, endViewport) {
+    for (const p of VIEWPORT_PROPS) {
+      if (Array.isArray(startViewport[p])) {
+        for (let i = 0; i < startViewport[p].length; ++i) {
+          if (startViewport[p][i] !== endViewport[p][i]) {
+            return false;
+          }
+        }
+      } else if (startViewport[p] !== endViewport[p]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  /* eslint-enable max-depth */
+
+  _createTransitionInterval(delay) {
+    if (this.transitionContext.interval) {
+      clearInterval(this.transitionContext.interval);
+    }
+    return setInterval(() => this._updateViewport(), delay);
+  }
+
+  _endTransition() {
+    clearInterval(this.transitionContext.interval);
+    this.transitionContext = {
+      time: 0,
+      delta: 0,
+      interval: null,
+      viewport: null,
+      startViewport: null,
+      endViewport: null
+    };
+  }
+
+  _isTransitionInProgress() {
+    return this.transitionContext.interval;
+  }
+
+  _isTransitionEnabled(props) {
+    return props.transitionDuration !== 0;
+  }
+
+  _isUpdateDueToCurrentTransition(nextProps) {
+    if (this.transitionContext.viewport) {
+      const newViewport = extractViewportFrom(nextProps);
+      return this._areViewportsEqual(newViewport, this.transitionContext.viewport);
+    }
+    return false;
+  }
+
+  _shouldIgnoreViewportChange(nextProps) {
+    // Ignore update if it is due to current active transition.
+    if (this._isUpdateDueToCurrentTransition(nextProps)) {
+      return true;
+    }
+
+    // Ignore update if it is requested to be ignored
+    if (this._isTransitionInProgress() &&
+      this.props.transitionInterruption === TRANSITION_EVENTS.IGNORE) {
+      return true;
+    }
+
+    // Ignore if none of the viewport props changed.
+    const start = extractViewportFrom(this.props);
+    const end = extractViewportFrom(nextProps);
+    if (this._areViewportsEqual(start, end)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  _shouldSnapToEnd() {
+    return (this.transitionContext.interval &&
+      this.props.transitionInterruption === TRANSITION_EVENTS.SNAP_TO_END);
+  }
+
+  _triggerTransition(startViewport, nextProps) {
+    assert(nextProps.transitionDuration !== 0);
+    const delta = 1000.0 / (nextProps.transitionDuration * VIEWPORT_TRANSITION_FREQUENCY);
+    const endViewport = extractViewportFrom(nextProps);
+    const interval = this._createTransitionInterval(1000 / VIEWPORT_TRANSITION_FREQUENCY);
+    assert(delta < 1.0);
+    this.transitionContext = {
+      time: delta,
+      delta,
+      startViewport,
+      endViewport,
+      interval,
+      viewport: startViewport
+    };
+  }
+
+  _updateViewport() {
+    // NOTE: Be cautious re-ordering statements in this function.
+    const time = this.transitionContext.time;
+    const delta = this.transitionContext.delta;
+    const easing = this.props.transitionEasing(time);
+    const viewport = this.props.transitionInterpolator(
+      this.transitionContext.startViewport,
+      this.transitionContext.endViewport,
+      easing
+    );
+    assert(time <= 1.0);
+    this.transitionContext.viewport = Object.assign(
+      {},
+      this.transitionContext.endViewport,
+      viewport);
+    if (this.onTransitionUpdate) {
+      const mapState = new MapState(Object.assign({}, this.props, viewport));
+      this.onTransitionUpdate(mapState.getViewportProps());
+    }
+
+    if (time === 1.0) {
+      this._endTransition();
+      this.props.onTransitionEnd();
+    } else {
+      // Make sure interplation step is always ends with time = 1.0
+      this.transitionContext.time = (time + delta) > 1.0 ? 1.0 : (time + delta);
+    }
+  }
+}
+
+TransitionManager.defaultProps = DEFAULT_PROPS;

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -27,9 +27,9 @@ const DEFAULT_PROPS = {
 };
 
 export default class TransitionManager {
-  constructor(props, onTransitionUpdate) {
+  constructor(props) {
     this.props = props;
-    this.onTransitionUpdate = onTransitionUpdate;
+
     this.transitionContext = {
       time: 0,
       delta: 0,
@@ -191,9 +191,9 @@ export default class TransitionManager {
       {},
       this.transitionContext.endViewport,
       viewport);
-    if (this.onTransitionUpdate) {
+    if (this.props.onViewportChange) {
       const mapState = new MapState(Object.assign({}, this.props, viewport));
-      this.onTransitionUpdate(mapState.getViewportProps());
+      this.props.onViewportChange(mapState.getViewportProps());
     }
 
     if (time === 1.0) {

--- a/src/utils/viewport-transition-utils.js
+++ b/src/utils/viewport-transition-utils.js
@@ -4,8 +4,10 @@ import {projectFlat, unprojectFlat} from 'viewport-mercator-project';
 import {Vector2} from 'math.gl';
 
 const EPSILON = 0.01;
-export const VIEWPORT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch',
+const VIEWPORT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch',
   'position', 'width', 'height'];
+const VIEWPORT_INTERPOLATION_PROPS =
+  ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'];
 
 export function extractViewportFrom(props) {
   const viewport = {};
@@ -17,6 +19,23 @@ export function extractViewportFrom(props) {
   return viewport;
 }
 
+/* eslint-disable max-depth */
+export function areViewportsEqual(startViewport, endViewport) {
+  for (const p of VIEWPORT_INTERPOLATION_PROPS) {
+    if (Array.isArray(startViewport[p])) {
+      for (let i = 0; i < startViewport[p].length; ++i) {
+        if (startViewport[p][i] !== endViewport[p][i]) {
+          return false;
+        }
+      }
+    } else if (startViewport[p] !== endViewport[p]) {
+      return false;
+    }
+  }
+  return true;
+}
+/* eslint-enable max-depth */
+
 /**
  * Performs linear interpolation of two viewports.
  * @param {Object} startViewport - object containing starting viewport parameters.
@@ -26,8 +45,6 @@ export function extractViewportFrom(props) {
 */
 export function viewportLinearInterpolator(startViewport, endViewport, t) {
   const viewport = Object.assign({}, endViewport);
-  const VIEWPORT_INTERPOLATION_PROPS =
-    ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'];
   function lerp(start, end, step) {
     if (Array.isArray(start)) {
       return start.map((element, index) => {

--- a/src/utils/viewport-transition-utils.js
+++ b/src/utils/viewport-transition-utils.js
@@ -1,0 +1,138 @@
+/* eslint max-statements: ["error", 50] */
+
+import {projectFlat, unprojectFlat} from 'viewport-mercator-project';
+import {Vector2} from 'math.gl';
+
+const EPSILON = 0.01;
+export const VIEWPORT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch',
+  'position', 'width', 'height'];
+
+export function extractViewportFrom(props) {
+  const viewport = {};
+  VIEWPORT_PROPS.forEach((key) => {
+    if (typeof props[key] !== 'undefined') {
+      viewport[key] = props[key];
+    }
+  });
+  return viewport;
+}
+
+/**
+ * Performs linear interpolation of two viewports.
+ * @param {Object} startViewport - object containing starting viewport parameters.
+ * @param {Object} endViewport - object containing ending viewport parameters.
+ * @param {Number} t - interpolation step.
+ * @return {Object} - interpolated viewport for given step.
+*/
+export function viewportLinearInterpolator(startViewport, endViewport, t) {
+  const viewport = Object.assign({}, endViewport);
+  const VIEWPORT_INTERPOLATION_PROPS =
+    ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'];
+  function lerp(start, end, step) {
+    if (Array.isArray(start)) {
+      return start.map((element, index) => {
+        return lerp(element, end[index], step);
+      });
+    }
+    return step * end + (1 - step) * start;
+  }
+
+  for (const p of VIEWPORT_INTERPOLATION_PROPS) {
+    const startValue = startViewport[p];
+    const endValue = endViewport[p];
+    // TODO: 'position' is not always specified
+    if (typeof startValue !== 'undefined' && typeof endValue !== 'undefined') {
+      viewport[p] = lerp(startValue, endValue, t);
+    }
+  }
+  return viewport;
+}
+
+/**
+ * This method adapts mapbox-gl-js Map#flyTo animation so it can be used in
+ * react/redux architecture.
+ * mapbox-gl-js flyTo : https://www.mapbox.com/mapbox-gl-js/api/#map#flyto.
+ * It implements “Smooth and efficient zooming and panning.” algorithm by
+ * "Jarke J. van Wijk and Wim A.A. Nuij"
+ *
+ * @param {Object} startViewport - object containing starting viewport parameters.
+ * @param {Object} endViewport - object containing ending viewport parameters.
+ * @param {Number} t - interpolation step.
+ * @return {Object} - interpolated viewport for given step.
+*/
+export function viewportFlyToInterpolator(startViewport, endViewport, t) {
+  // Equations from above paper are referred where needed.
+
+  const viewport = Object.assign({}, endViewport);
+
+  function lerp(start, end, step) {
+    return step * end + (1 - step) * start;
+  }
+  function zoomToScale(zoom) {
+    return Math.pow(2, zoom);
+  }
+  function scaleToZoom(scale) {
+    return Math.log(scale) / Math.LN2;
+  }
+
+  // TODO: add this as an option for applications.
+  const rho = 1.414;
+
+  const startZoom = startViewport.zoom;
+  const startCenter = [startViewport.longitude, startViewport.latitude];
+  const startScale = zoomToScale(startZoom);
+  const endZoom = endViewport.zoom;
+  const endCenter = [endViewport.longitude, endViewport.latitude];
+  const scale = zoomToScale(endZoom - startZoom);
+
+  const startCenterXY = new Vector2(projectFlat(startCenter, startScale));
+  const endCenterXY = new Vector2(projectFlat(endCenter, startScale));
+  const uDelta = endCenterXY.subtract(startCenterXY);
+
+  const w0 = Math.max(startViewport.width, startViewport.height);
+  const w1 = w0 / scale;
+  const u1 = Math.sqrt((uDelta.x * uDelta.x) + (uDelta.y * uDelta.y));
+  // u0 is treated as '0' in Eq (9).
+
+  // Linearly interpolate 'bearing' and 'pitch'
+  for (const p of ['bearing', 'pitch']) {
+    const startValue = startViewport[p];
+    const endValue = endViewport[p];
+    viewport[p] = lerp(startValue, endValue, t);
+  }
+
+  // If change in center is too small, do linear interpolaiton.
+  if (Math.abs(u1) < EPSILON) {
+    for (const p of ['latitude', 'longitude', 'zoom']) {
+      const startValue = startViewport[p];
+      const endValue = endViewport[p];
+      viewport[p] = lerp(startValue, endValue, t);
+    }
+    return viewport;
+  }
+
+  // Implement Equation (9) from above algorithm.
+  const rho2 = rho * rho;
+  const b0 = (w1 * w1 - w0 * w0 + rho2 * rho2 * u1 * u1) / (2 * w0 * rho2 * u1);
+  const b1 = (w1 * w1 - w0 * w0 - rho2 * rho2 * u1 * u1) / (2 * w1 * rho2 * u1);
+  const r0 = Math.log(Math.sqrt(b0 * b0 + 1) - b0);
+  const r1 = Math.log(Math.sqrt(b1 * b1 + 1) - b1);
+  function w(s) {
+    return (Math.cosh(r0) / Math.cosh(r0 + rho * s));
+  }
+  function u(s) {
+    return w0 * ((Math.cosh(r0) * Math.tanh(r0 + rho * s) - Math.sinh(r0)) / rho2) / u1;
+  }
+  const S = (r1 - r0) / rho;
+  const s = t * S;
+  const scaleIncrement = 1 / w(s); // Using w method for scaling.
+  const newZoom = startZoom + scaleToZoom(scaleIncrement);
+
+  const newCenter = unprojectFlat(
+    (startCenterXY.add(uDelta.scale(u(s)))).scale(scaleIncrement),
+    zoomToScale(newZoom));
+  viewport.longitude = newCenter[0];
+  viewport.latitude = newCenter[1];
+  viewport.zoom = newZoom;
+  return viewport;
+}


### PR DESCRIPTION
New `InteractiveMap` props:
- Transition props
  - `transitionDuration`
  - `transitionInterpolator`
  - `transitionInterruption`
  - `transitionEasing`
- Transition callbacks
  - `onTransitionStart`
  - `onTransitionInterrupt`
  - `onTransitionEnd`

The transition props are also introduced into `MapControls` as it needs to manipulate their values.