### PR TITLE
Only show access token error if Mapbox data is used

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -35,6 +35,8 @@ const NO_TOKEN_WARNING = 'A valid API access token is required to use Mapbox dat
 
 function noop() {}
 
+const UNAUTHORIZED_ERROR_CODE = 401;
+
 const propTypes = Object.assign({}, Mapbox.propTypes, {
   /** The Mapbox style. A string url or a MapboxGL style Immutable.Map object. */
   mapStyle: PropTypes.oneOfType([
@@ -180,7 +182,8 @@ export default class StaticMap extends PureComponent {
 
   // Handle map error
   _mapboxMapError(evt) {
-    if (evt.error && evt.error.status === 401 && !this.state.accessTokenInvalid) {
+    if (evt.error && evt.error.status === UNAUTHORIZED_ERROR_CODE &&
+      !this.state.accessTokenInvalid) {
       // Mapbox throws unauthorized error - invalid token
       console.error(NO_TOKEN_WARNING); // eslint-disable-line
       this.setState({accessTokenInvalid: true});

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -39,6 +39,7 @@ const propTypes = {
   attributionControl: PropTypes.bool, /** Show attribution control or not. */
   preserveDrawingBuffer: PropTypes.bool, /** Useful when you want to export the canvas as a PNG. */
   onLoad: PropTypes.func, /** The onLoad callback for the map */
+  onError: PropTypes.func, /** The onError callback for the map */
   reuseMaps: PropTypes.bool,
 
   mapStyle: PropTypes.string, /** The Mapbox style. A string url to a MapboxGL style */
@@ -63,6 +64,7 @@ const defaultProps = {
   attributionControl: true,
   preventStyleDiffing: false,
   onLoad: noop,
+  onError: noop,
   reuseMaps: false,
 
   mapStyle: 'mapbox://styles/mapbox/light-v8',
@@ -177,6 +179,7 @@ export default class Mapbox {
       });
       // Attach optional onLoad function
       this.map.once('load', props.onLoad);
+      this.map.on('error', props.onError);
       console.debug('Created new mapbox map', this._map); // eslint-disable-line
     }
 
@@ -201,7 +204,6 @@ export default class Mapbox {
     // Creation only props
     if (mapboxgl) {
       if (!this.accessToken) {
-        console.error('An API access token is required to use Mapbox GL'); // eslint-disable-line
         mapboxgl.accessToken = 'no-token'; // Prevents mapbox from throwing
       } else {
         mapboxgl.accessToken = this.accessToken;


### PR DESCRIPTION
Only warn about access token in console & canvas upon an unauthorized attempt to access Mapbox service.
This will eliminate the confusing message for non-mapbox-data users such as https://github.com/uber/react-map-gl/issues/385