### PR TITLE
Fix eventManager error on map unmount

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -283,6 +283,7 @@ export default class InteractiveMap extends PureComponent {
   }
 
   _eventCanvasLoaded(ref) {
+    // This will be called with `null` after unmount, releasing event manager resource
     this._eventManager.setElement(ref);
   }
 

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -196,13 +196,6 @@ export default class InteractiveMap extends PureComponent {
     this._transitionManager.processViewportChange(nextProps);
   }
 
-  componentWillUnmount() {
-    if (this._eventManager) {
-      // Must destroy because hammer adds event listeners to window
-      this._eventManager.destroy();
-    }
-  }
-
   getMap() {
     return this._map.getMap();
   }


### PR DESCRIPTION
`componentWillUnmount` calls `_eventManager.destroy`.

```
_eventCanvasLoaded(ref) {
  this._eventManager.setElement(ref);
}
```
Is called immediately following unmount ([doc](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element)), setting canvas element to `null`, which also calls `_eventManager.destroy` and throws an error as it is already deconstructed.