### PR TITLE
mapbox-gl to 0.42.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-runtime": "^6.23.0",
     "bowser": "^1.2.0",
     "immutable": "*",
-    "mapbox-gl": "0.41.0",
+    "mapbox-gl": "0.42.2",
     "math.gl": ">= 1.0.0-alpha.8",
     "mjolnir.js": ">=1.0.0-alpha.1",
     "prop-types": "^15.5.7",


### PR DESCRIPTION
track set of changes here https://github.com/mapbox/mapbox-gl-js/releases, breaking changes were in `0.42.0`