### PR TITLE
Relax mapStyle prop type check

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -41,6 +41,7 @@ const propTypes = Object.assign({}, Mapbox.propTypes, {
   /** The Mapbox style. A string url or a MapboxGL style Immutable.Map object. */
   mapStyle: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.object,
     PropTypes.instanceOf(Immutable.Map)
   ]),
   /** There are known issues with style diffing. As stopgap, add option to prevent style diffing. */


### PR DESCRIPTION
https://github.com/uber/react-map-gl/issues/396
We do handle plain JavaScript style objects in code, no reason not to allow it in prop type check.