### PR TITLE
[3.2.0] Implement touch rotate

### DIFF
--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -63,8 +63,11 @@ Enable drag to rotate.
 ##### `doubleClickZoom` {Bool} [default: true]
 Enable double click to zoom.
 
-##### `touchZoomRotate` {Bool} [default: true]
-Enable touch to zoom and rotate.
+##### `touchZoom` {Bool} [default: true]
+Enable multitouch zoom.
+
+##### `touchRotate` {Bool} [default: false]
+Enable multitouch rotate.
 
 ##### `clickRadius` {Number} [default: 0]
 Radius to detect features around a clicked point.

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -56,8 +56,10 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
   dragRotate: PropTypes.bool,
   // Double click to zoom
   doubleClickZoom: PropTypes.bool,
-  // Pinch to zoom / rotate
-  touchZoomRotate: PropTypes.bool,
+  // Multitouch zoom
+  touchZoom: PropTypes.bool,
+  // Multitouch rotate
+  touchRotate: PropTypes.bool,
   // Keyboard
   keyboard: PropTypes.bool,
 

--- a/src/utils/deprecate-warn.js
+++ b/src/utils/deprecate-warn.js
@@ -3,7 +3,8 @@ const DEPRECATED_PROPS = [
   {old: 'onChangeViewport', new: 'onViewportChange'},
   {old: 'perspectiveEnabled', new: 'dragRotate'},
   {old: 'onHoverFeatures', new: 'onHover'},
-  {old: 'onClickFeatures', new: 'onClick'}
+  {old: 'onClickFeatures', new: 'onClick'},
+  {old: 'touchZoomRotate', new: 'touchZoom, touchRotate'}
 ];
 
 function getDeprecatedText(name) {


### PR DESCRIPTION
- Add props `touchZoom` and `touchRotate`
  + `touchRotate` default to false to match 3.1 behavior
  + `touchRotate:false` is equivalent to Mapbox's `map.touchZoomRotate.disableRotation()`
- Show deprecation warning for `touchZoomRotate`