### PR TITLE
Add `transformRequest` prop to map components.

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,11 +1,24 @@
 # Testing
 
+## Unit, Lint
+
 ```
 npm run test
+```
+
+## Browser
+
+```
 npm run test-browser
 ```
 
-## Bumping Mapbox Version
+**You'll need to specify a valid Mapbox Access Token in the URL** for the tests to pass.
+
+```
+http://localhost:8080/?access_token=MAPBOX_ACCESS_TOKEN
+```
+
+# Bumping Mapbox Version
 
 Always pin Mapbox to a specific release.
 

--- a/docs/components/static-map.md
+++ b/docs/components/static-map.md
@@ -92,7 +92,7 @@ A callback run when the map emits a `load` event.
 A callback run when the map emits an `error` event.
 [Mapbox docs](https://www.mapbox.com/mapbox-gl-js/api#map.event:error)
 
-##### `transformRequest` {Function} - default: `undefined`
+##### `transformRequest` {Function} - default: `null`
 A callback run before the Map makes a request for an external URL. The callback can be used
 to modify the url, set headers, or set the credentials property for cross-origin requests.
 Expected to return an object with a `url` property and optionally `headers` and `credentials`

--- a/docs/components/static-map.md
+++ b/docs/components/static-map.md
@@ -84,6 +84,20 @@ map from reloading and flickering when the map style changes.
 
 There are known issues with style diffing. As stopgap, use this option to prevent style diffing.
 
+##### `onLoad` {Function} - default: `no-op function`
+A callback run when the map emits a `load` event.
+[Mapbox docs](https://www.mapbox.com/mapbox-gl-js/api#map.event:load)
+
+##### `onError` {Function} - default: `no-op function`
+A callback run when the map emits an `error` event.
+[Mapbox docs](https://www.mapbox.com/mapbox-gl-js/api#map.event:error)
+
+##### `transformRequest` {Function} - default: `undefined`
+A callback run before the Map makes a request for an external URL. The callback can be used
+to modify the url, set headers, or set the credentials property for cross-origin requests.
+Expected to return an object with a `url` property and optionally `headers` and `credentials`
+properties.  Equivalent to Mapbox's `transformRequest` [map option](https://www.mapbox.com/mapbox-gl-js/api#map).
+
 ## Methods
 
 ##### `getMap()`

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
     "reify": "^0.4.4",
-    "sinon": "^1.17.7",
+    "sinon": "4.1.3",
     "tap-browser-color": "^0.1.2",
     "tape": "^4.5.1",
     "tape-catch": "^1.0.4",

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -41,6 +41,7 @@ const propTypes = {
   onLoad: PropTypes.func, /** The onLoad callback for the map */
   onError: PropTypes.func, /** The onError callback for the map */
   reuseMaps: PropTypes.bool,
+  transformRequest: PropTypes.func, /** Usage: https://www.mapbox.com/mapbox-gl-js/api#requestparameters */
 
   mapStyle: PropTypes.string, /** The Mapbox style. A string url to a MapboxGL style */
   visible: PropTypes.bool, /** Whether the map is visible */
@@ -66,6 +67,7 @@ const defaultProps = {
   onLoad: noop,
   onError: noop,
   reuseMaps: false,
+  transformRequest: noop,
 
   mapStyle: 'mapbox://styles/mapbox/light-v8',
   visible: true,
@@ -175,7 +177,8 @@ export default class Mapbox {
         style: props.mapStyle,
         interactive: false,
         attributionControl: props.attributionControl,
-        preserveDrawingBuffer: props.preserveDrawingBuffer
+        preserveDrawingBuffer: props.preserveDrawingBuffer,
+        transformRequest: props.transformRequest
       });
       // Attach optional onLoad function
       this.map.once('load', props.onLoad);

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -41,7 +41,7 @@ const propTypes = {
   onLoad: PropTypes.func, /** The onLoad callback for the map */
   onError: PropTypes.func, /** The onError callback for the map */
   reuseMaps: PropTypes.bool,
-  transformRequest: PropTypes.func, /** Usage: https://www.mapbox.com/mapbox-gl-js/api#requestparameters */
+  transformRequest: PropTypes.func, /** The transformRequest callback for the map */
 
   mapStyle: PropTypes.string, /** The Mapbox style. A string url to a MapboxGL style */
   visible: PropTypes.bool, /** Whether the map is visible */
@@ -67,7 +67,7 @@ const defaultProps = {
   onLoad: noop,
   onError: noop,
   reuseMaps: false,
-  transformRequest: noop,
+  transformRequest: undefined,
 
   mapStyle: 'mapbox://styles/mapbox/light-v8',
   visible: true,

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -67,7 +67,7 @@ const defaultProps = {
   onLoad: noop,
   onError: noop,
   reuseMaps: false,
-  transformRequest: undefined,
+  transformRequest: null,
 
   mapStyle: 'mapbox://styles/mapbox/light-v8',
   visible: true,
@@ -168,7 +168,7 @@ export default class Mapbox {
       props.onLoad();
       console.debug('Reused existing mapbox map', this._map); // eslint-disable-line
     } else {
-      this._map = this.map = new mapboxgl.Map({
+      const mapOptions = {
         container: props.container || document.body,
         center: [props.longitude, props.latitude],
         zoom: props.zoom,
@@ -177,9 +177,13 @@ export default class Mapbox {
         style: props.mapStyle,
         interactive: false,
         attributionControl: props.attributionControl,
-        preserveDrawingBuffer: props.preserveDrawingBuffer,
-        transformRequest: props.transformRequest
-      });
+        preserveDrawingBuffer: props.preserveDrawingBuffer
+      };
+      // We don't want to pass a null or no-op transformRequest function.
+      if (props.transformRequest) {
+        mapOptions.transformRequest = props.transformRequest;
+      }
+      this._map = this.map = new mapboxgl.Map(mapOptions);
       // Attach optional onLoad function
       this.map.once('load', props.onLoad);
       this.map.on('error', props.onError);

--- a/test/components/map.spec.js
+++ b/test/components/map.spec.js
@@ -79,3 +79,30 @@ test('Interactive map renders children on first render', t => {
   t.ok(childComponent.called, 'Child rendered');
   t.end();
 });
+
+test('Interactive map#call transformRequest callback when provided', t => {
+  function transformRequest(url, resourceType) {
+    t.ok(true, 'transformRequest handler was called');
+    t.end();
+  }
+
+  const props = Object.assign({}, defaultProps, {transformRequest});
+
+  const map = createElement(InteractiveMap, props);
+
+  // const result = ReactTestUtils.createRenderer().render(map);
+  const result = ReactTestRenderer.create(map);
+
+  t.ok(result, 'InteractiveMap rendered');
+
+  if (!InteractiveMap.supported()) {
+    t.ok('transformRequest not called since InteractiveMap.supported() false');
+    t.end();
+  } else {
+    /* global setTimeout */
+    setTimeout(() => {
+      t.fail('transformRequest wasn\'t called');
+      t.end();
+    }, 1000);
+  }
+});

--- a/test/components/map.spec.js
+++ b/test/components/map.spec.js
@@ -40,7 +40,7 @@ test('InteractiveMap#named export', t => {
 
 test('InteractiveMap#call onLoad when provided', t => {
   function onLoad(...args) {
-    t.ok(args.length, 0, 'onLoad does not expose the map object.');
+    t.is(args.length, 0, 'onLoad does not expose the map object.');
     t.end();
   }
 
@@ -48,7 +48,7 @@ test('InteractiveMap#call onLoad when provided', t => {
 
   const map = createElement(InteractiveMap, props);
 
-  const result = ReactTestUtils.createRenderer().render(map);
+  const result = ReactTestRenderer.create(map);
 
   t.ok(result, 'InteractiveMap rendered');
 
@@ -60,7 +60,7 @@ test('InteractiveMap#call onLoad when provided', t => {
     setTimeout(() => {
       t.fail('onLoad wasn\'t called');
       t.end();
-    }, 1000);
+    }, 5000);
   }
 });
 

--- a/test/node.js
+++ b/test/node.js
@@ -5,6 +5,7 @@ require('reify');
 const path = require('path');
 const moduleAlias = require('module-alias');
 
+// Needed for `npm run test`, whereas `npm run test-browser` alias is declared in webpack.config.js
 moduleAlias.addAlias('react-map-gl', path.resolve('./src'));
 
 // Run the tests

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,6 +1379,10 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
+diff@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -1849,6 +1853,12 @@ express@^4.13.3:
     utils-merge "1.0.0"
     vary "~1.1.1"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -2019,11 +2029,11 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.2"
@@ -2128,9 +2138,21 @@ github-from-package@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
 
+gl-mat3@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gl-mat3/-/gl-mat3-1.0.0.tgz#89633219ca429379a16b9185d95d41713453b912"
+
 gl-mat4@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/gl-mat4/-/gl-mat4-1.1.4.tgz#1e895b55892e56a896867abd837d38f37a178086"
+
+gl-quat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gl-quat/-/gl-quat-1.0.0.tgz#0945ec923386f45329be5dc357b1c8c2d47586c5"
+  dependencies:
+    gl-mat3 "^1.0.0"
+    gl-vec3 "^1.0.3"
+    gl-vec4 "^1.0.0"
 
 gl-vec2@^1.0.0:
   version "1.0.0"
@@ -2140,7 +2162,7 @@ gl-vec3@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/gl-vec3/-/gl-vec3-1.0.3.tgz#110fd897d0729f6398307381567d0944941bf22b"
 
-gl-vec4@^1.0.1:
+gl-vec4@^1.0.0, gl-vec4@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gl-vec4/-/gl-vec4-1.0.1.tgz#97d96878281b14b532cbce101785dfd1cb340964"
 
@@ -2220,6 +2242,15 @@ glsl-tokenizer@^2.0.2:
 graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+gray-matter@^3.0.8:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-3.1.1.tgz#101f80d9e69eeca6765cdce437705b18f40876ac"
+  dependencies:
+    extend-shallow "^2.0.1"
+    js-yaml "^3.10.0"
+    kind-of "^5.0.2"
+    strip-bom-string "^1.0.0"
 
 grid-index@^1.0.0:
   version "1.0.0"
@@ -2560,7 +2591,7 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
@@ -2718,7 +2749,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.5.1:
+js-yaml@^3.10.0, js-yaml@^3.5.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2820,6 +2851,10 @@ jsx-ast-utils@^1.3.3, jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
+just-extend@^1.1.26:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 kdbush@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-1.0.1.tgz#3cbd03e9dead9c0f6f66ccdb96450e5cecc640e0"
@@ -2835,6 +2870,10 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -2896,6 +2935,10 @@ lodash.assign@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -2935,9 +2978,13 @@ loglevel@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.0.tgz#3863984a2c326b986fbb965f378758a6dc8a4324"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.1.tgz#3d2319894471ea0950ef64692ead2a5318cff362"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2972,9 +3019,9 @@ mapbox-gl-supported@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz#cbd34df894206cadda9a33c8d9a4609f26bb1989"
 
-mapbox-gl@0.40.1:
-  version "0.40.1"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.40.1.tgz#14785b1ab3bc7a42fd24fcb37637ebcec817c5f1"
+mapbox-gl@0.42.2:
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.42.2.tgz#b349142d0b0a3c2f4225b30d301c9bf6c507a272"
   dependencies:
     "@mapbox/gl-matrix" "^0.0.1"
     "@mapbox/point-geometry" "^0.1.0"
@@ -2989,6 +3036,7 @@ mapbox-gl@0.40.1:
     earcut "^2.0.3"
     geojson-rewind "^0.2.0"
     geojson-vt "^2.4.0"
+    gray-matter "^3.0.8"
     grid-index "^1.0.0"
     jsonlint-lines-primitives "~1.6.0"
     lodash.isequal "^3.0.4"
@@ -3007,6 +3055,16 @@ mapbox-gl@0.40.1:
     unflowify "^1.0.0"
     vt-pbf "^3.0.1"
     webworkify "^1.4.0"
+
+"math.gl@>= 1.0.0-alpha.8", math.gl@^1.0.0-alpha.7:
+  version "1.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-1.0.0-alpha.8.tgz#51dd8d03e5c50096851e8a268d888c1eda766cd1"
+  dependencies:
+    gl-mat4 "^1.1.4"
+    gl-quat "^1.0.0"
+    gl-vec2 "^1.0.0"
+    gl-vec3 "^1.0.3"
+    gl-vec4 "^1.0.1"
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -3109,9 +3167,9 @@ minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mjolnir.js@>=0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-0.1.0.tgz#0bb55a8baa00185630309f0d3a57dd161b56acfd"
+mjolnir.js@>=1.0.0-alpha.1:
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-1.0.0-alpha.2.tgz#c7fed2b660dc8b2cf40977b5a38d6a02c0f93d2a"
   dependencies:
     hammerjs "^2.0.8"
 
@@ -3161,6 +3219,16 @@ natural-compare@^1.4.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+nise@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.0.tgz#079d6cadbbcb12ba30e38f1c999f36ad4d6baa53"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.26"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-abi@^2.0.0:
   version "2.1.1"
@@ -3507,6 +3575,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -4067,13 +4141,9 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-samsam@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
-
-samsam@~1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+samsam@1.x:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
 sax@^1.1.4:
   version "1.2.4"
@@ -4202,14 +4272,17 @@ simple-get@^1.4.2:
     unzip-response "^1.0.0"
     xtend "^4.0.0"
 
-sinon@^1.17.7:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.1.3.tgz#fc599eda47ed9f1a694ce774b94ab44260bd7ac5"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^4.4.0"
+    type-detect "^4.0.5"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -4442,6 +4515,10 @@ strip-ansi@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
 
+strip-bom-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -4479,6 +4556,12 @@ supports-color@^3.1.0:
 supports-color@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  dependencies:
+    has-flag "^2.0.0"
+
+supports-color@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 
@@ -4567,6 +4650,10 @@ tar@^2.0.0, tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -4664,6 +4751,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
 type-is@~1.6.15:
   version "1.6.15"
@@ -4774,7 +4865,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
+util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
@@ -4817,14 +4908,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viewport-mercator-project@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-4.1.1.tgz#92b0611fa0041041d2f3568da3529a8a846017d0"
+viewport-mercator-project@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-5.0.0-alpha.1.tgz#637b849517f4fc3898028a89210d244b412011e0"
   dependencies:
-    gl-mat4 "^1.1.4"
-    gl-vec2 "^1.0.0"
-    gl-vec3 "^1.0.3"
-    gl-vec4 "^1.0.1"
+    math.gl "^1.0.0-alpha.7"
 
 vlq@^0.2.1:
   version "0.2.2"


### PR DESCRIPTION
- [x] Add `transformRequest` to props and map constructor
- [x] Document `transformRequest` prop
- [x] Test `transformRequest` prop
- [x] Upgrade `sinon` to fix `test-browser` script
- [ ] Fix map `onLoad` tests

The mapboxgl `transformRequest` map option is necessary when you need to modify the request headers, for example when your data sources require an `Authorization` header.

Example from our app:

```
    transformRequest = (url, resourceType) => {
        if (resourceType == 'Tile' && url.startsWith('https://example.authenticated.com')) {
            return {
                url: url,
                headers: {
                    Authorization: 'Bearer $token'.replace('$token', localStorage.getItem('authToken'))
                }
            }
        }
    }

    render() {
        return (
            <ReactMapGL ... transformRequest={this.transformRequest} />
        )
    }
```

Unfortunately, there's no way to set the map's `transformRequest` option outside of the constructor.

It might be worth considering passing-through all unknown props to the `mapboxgl.map()` constructor, rather than dealing with them individually like this, but I didn't want to make that sweeping decision or tackle that problem right now.