### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -129,7 +129,6 @@ const defaultProps = Object.assign({},
     dragPan: true,
     dragRotate: true,
     doubleClickZoom: true,
-    touchZoomRotate: true,
 
     clickRadius: 0,
     getCursor: getDefaultCursor,


### PR DESCRIPTION
- Do not set deprecated prop by default.
- We are handling default case of this in `MapControls.setOptions`.

Verified with `test-browser`.