### PR TITLE
Restore immutable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "bowser": "^1.2.0",
+    "immutable": "*",
     "mapbox-gl": "0.42.2",
     "math.gl": "^1.0.0",
     "mjolnir.js": "^1.0.0",


### PR DESCRIPTION
This is to restore `immutable` to the package dependencies list, removed in https://github.com/uber/react-map-gl/pull/433

- For apps not using immutable, it is not going to be bundled.
- Existing applications that are using immutable will continue to work after upgrading to 3.2.

`immutable` should be removed in the next major release.
