### PR TITLE
Include dist-es6 in published npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "module": "dist-es6/index.js",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "dist-es6"
   ],
   "scripts": {
     "start": "(cd examples/main && (path-exists node_modules || npm i) && npm run start-local)",


### PR DESCRIPTION
Otherwise bundlers will look at `package.module` which points to a file in `dist-es6` that isn't there. See https://github.com/parcel-bundler/parcel/issues/671.