### PR TITLE
Use latest version of `mjolnir.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "immutable": "*",
     "mapbox-gl": "0.42.2",
     "math.gl": "^1.0.0",
-    "mjolnir.js": "^1.0.0",
+    "mjolnir.js": "^1.0.1",
     "prop-types": "^15.5.7",
     "viewport-mercator-project": "^5.0.0"
   },


### PR DESCRIPTION
This is required for the full library to work with `parcel-bundler`. See the [initial issue on Parcel](parcel-bundler/parcel#671), the [initial PR](https://github.com/uber/react-map-gl/pull/447) and the [PR for mjolnir](https://github.com/uber-web/mjolnir.js/pull/11).

If you could republish after this as well, that would be great :)
I'm excited to use react-map-gl!