### PR TITLE
Add this._map sanity check in getMap()

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -198,7 +198,7 @@ export default class InteractiveMap extends PureComponent {
   }
 
   getMap() {
-    return this._map.getMap();
+    return this._map ? this._map.getMap() : null;
   }
 
   queryRenderedFeatures(geometry, options) {


### PR DESCRIPTION
Since the `_map` reference gets set to null on `componentWillUnmount`, doing a `getMap()` in my own component on unmount crashes. Currently, the only way to circumvent that is to assert on the private _map field. This should fix that.