### PR TITLE
Wrong latitude in Popup example

### DIFF
--- a/docs/components/popup.md
+++ b/docs/components/popup.md
@@ -10,8 +10,8 @@ import ReactMapGL, {Popup} from 'react-map-gl';
 class Map extends Component {
   render() {
     return (
-      <ReactMapGL latitude={-122.41} longitude={37.78} zoom={8}>
-        <Popup latitude={-122.41} longitude={37.78} closeButton={true} closeOnClick={false} anchor="top">
+      <ReactMapGL latitude={-17.44} longitude={37.78} zoom={8}>
+        <Popup latitude={-17.44} longitude={37.78} closeButton={true} closeOnClick={false} anchor="top">
           <div>You are here</div>
         </Popup>
       </ReactMapGL>


### PR DESCRIPTION
Using the Popup example will fail because latitude is out of boundaries (throws an AssertionError). This fixes it, using some place on the coast of Mozambique, because why not.