### PR TITLE
Typo fix in state-management.md docs

### DIFF
--- a/docs/get-started/state-management.md
+++ b/docs/get-started/state-management.md
@@ -32,7 +32,7 @@ Or manipulate the viewport outside of the ReactMap component:
 
 ```jsx
 _goToNYC = () => {
-    const viewport = {...this.state, longitude: -74.1, latitude: 40.7};
+    const viewport = {...this.state.viewport, longitude: -74.1, latitude: 40.7};
     this.setState({viewport});
 }
 


### PR DESCRIPTION
Small change here, but I stumbled over this step when working my way through the docs.

```
_goToNYC = () => {
    const viewport = {...this.state, longitude: -74.1, latitude: 40.7};
    this.setState({viewport});
}
```
Shouldn't this be _this.state.viewport_ ? 
Previous code example as written results in a viewport object within a viewport object.