### PR TITLE
More flexible width/height handling

### DIFF
--- a/docs/components/static-map.md
+++ b/docs/components/static-map.md
@@ -33,11 +33,11 @@ The Mapbox style. A string url or a
 [MapboxGL style](https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive)
 object (regular JS object or Immutable.Map).
 
-##### `width` {Number} (required)
-The width of the map.
+##### `width` {Number|String}
+The width of the map, if supplied must be either a number in pixels or valid CSS string (e.g. '100%')
 
-##### `height` {Number} (required)
-The height of the map.
+##### `height` {Number|String}
+The height of the map, if supplied must be either a number in pixels or valid CSS string (e.g. '100%')
 
 ##### `latitude` {Number} (required)
 The latitude of the center of the map.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,3 +1,8 @@
+# react-map-gl v3.3
+
+- **Flexible width and height props** - The `width` and `height` properties can now be set to any CSS strings, or they can be omitted for cases where they will be set by other React components.
+
+
 # react-map-gl v3.2
 
 Realease date: January, 2018

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -46,8 +46,9 @@ const propTypes = {
   visible: PropTypes.bool, /** Whether the map is visible */
 
   // Map view state
-  width: PropTypes.number.isRequired, /** The width of the map. */
-  height: PropTypes.number.isRequired, /** The height of the map. */
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), /** The width of the map. */
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), /** The height of the map. */
+
   longitude: PropTypes.number.isRequired, /** The longitude of the center of the map. */
   latitude: PropTypes.number.isRequired, /** The latitude of the center of the map. */
   zoom: PropTypes.number.isRequired, /** The tile zoom level of the map. */
@@ -123,6 +124,8 @@ export default class Mapbox {
     }
 
     this.props = {};
+    this.width = 0;
+    this.height = 0;
     this._initialize(props);
   }
 
@@ -278,10 +281,20 @@ export default class Mapbox {
     }
   }
 
+  // If canvas size has changed, reads out the new size and returns true
+  _checkForContainerSizeChange() {
+    const {canvas} = this;
+    if (canvas && (this.width !== canvas.clientWidth || this.height !== canvas.clientHeight)) {
+      this.width = canvas.clientWidth;
+      this.height = canvas.clientHeight;
+      return true;
+    }
+    return false;
+  }
+
   // Note: needs to be called after render (e.g. in componentDidUpdate)
   _updateMapSize(oldProps, newProps) {
-    const sizeChanged = oldProps.width !== newProps.width || oldProps.height !== newProps.height;
-    if (sizeChanged) {
+    if (this._checkForContainerSizeChange()) {
       this._map.resize();
     }
   }


### PR DESCRIPTION
Matching the changes in deck.gl.

- Ability to specify CSS strings like `100%` instead of hard-coding numbers.
- When using a `StaticMap` as a child of `DeckGL` there is no need to specify any `width` and/or `height`