### PR TITLE
Update main example to babel-loader@8

### DIFF
--- a/examples/main/index.html
+++ b/examples/main/index.html
@@ -7,6 +7,6 @@
     <style>body {margin: 0; padding: 0}</style>
   </head>
   <body>
-    <script src='bundle.js'></script>
+    <script src='app.js'></script>
   </body>
 </html>

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -19,16 +19,23 @@
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.2.0",
-    "babel-core": "^6.21.0",
-    "babel-loader": "^6.2.10",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-2": "^6.18.0",
+    "@babel/cli": "7.0.0-beta.44",
+    "@babel/core": "^7.0.0-beta.44",
+    "@babel/preset-env": "7.0.0-beta.44",
+    "@babel/preset-stage-2": "7.0.0-beta.44",
+    "@babel/preset-react": "7.0.0-beta.44",
+    "babel-eslint": "^6.0.0",
+    "babel-plugin-istanbul": "^4.1.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-plugin-version-inline": "^1.0.0",
+    "babel-preset-minify": "^0.4.0-alpha.caaefb4c",
+    "babel-loader": "^8.0.0-beta.2",
     "css-loader": "^0.28.4",
-    "node-sass": "^4.5.3",
-    "sass-loader": "^6.0.6",
-    "style-loader": "^0.18.2",
-    "webpack": "^2.4.0",
-    "webpack-dev-server": "^2.4.0"
+    "node-sass": "^4.8.3",
+    "sass-loader": "^7.0.0",
+    "style-loader": "^0.20.3",
+    "webpack": "^4.3.0",
+    "webpack-cli": "^2.0.13",
+    "webpack-dev-server": "^3.1.1"
   }
 }

--- a/examples/main/webpack.config.js
+++ b/examples/main/webpack.config.js
@@ -8,15 +8,15 @@ const webpack = require('webpack');
 // https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   presets: [
-    'es2015',
-    'react',
-    'stage-2'
-  ].map(function configMap(name) {
-    return require.resolve(`babel-preset-${name}`);
-  })
+    require.resolve('@babel/preset-env'),
+    require.resolve('@babel/preset-stage-2'),
+    require.resolve('@babel/preset-react')
+  ]
 };
 
 const config = {
+  mode: 'development',
+
   // Example entry point
   entry: {
     app: resolve('./root.js')
@@ -47,7 +47,7 @@ const config = {
       }]
     }, {
       test: /\.scss$/,
-      loaders: ['style-loader', 'css-loader', 'sass-loader', 'autoprefixer-loader']
+      loaders: ['style-loader', 'css-loader', 'sass-loader']
     }]
   },
 


### PR DESCRIPTION
For #473

Requires removing `autoprefixer-loader`. 