### PR TITLE
Unblock default wheel behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "bowser": "^1.2.0",
     "immutable": "*",
     "mapbox-gl": "0.44",
-    "math.gl": ">=1.1.0-alpha.2",
-    "mjolnir.js": "^1.0.0",
+    "math.gl": "^1.1.0",
+    "mjolnir.js": "^1.1.0",
     "prop-types": "^15.5.7",
-    "viewport-mercator-project": ">=5.1.0-alpha.1"
+    "viewport-mercator-project": "^5.1.0"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.44",

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -164,7 +164,7 @@ export default class InteractiveMap extends PureComponent {
     // Cannot use defaultProps here because it needs to be per map instance
     this._mapControls = props.mapControls || new MapControls();
 
-    this._eventManager = new EventManager(null, {rightButton: true});
+    this._eventManager = new EventManager(null, {rightButton: true, legacyBlockScroll: false});
 
     this.getMap = this.getMap.bind(this);
     this.queryRenderedFeatures = this.queryRenderedFeatures.bind(this);

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -269,6 +269,8 @@ export default class MapControls {
       return false;
     }
 
+    event.srcEvent.preventDefault();
+
     const pos = this.getCenter(event);
     const {delta} = event;
 


### PR DESCRIPTION
https://github.com/uber/react-map-gl/issues/464

#### Changelist
- Upgrade to latest dependencies
- Only call `preventDefault` if the map is zooming