### PR TITLE
Adds documentation on passing mapbox token as a prop

### DIFF
--- a/docs/get-started/mapbox-tokens.md
+++ b/docs/get-started/mapbox-tokens.md
@@ -7,5 +7,6 @@ There are several ways to provide a token to your app, as showcased in some of t
 * Modify the source directly
 * Set the `MapboxAccessToken` environment variable
 * Provide it in the URL, e.g `?access_token=TOKEN`
+* Pass it as a prop to the ReactMapGL instance `<ReactMapGL mapboxApiAccessToken={TOKEN} />`
 
 But we would recommend using something like [dotenv](https://github.com/motdotla/dotenv) and put your key in an untracked `.env` file, that will then expose it as a `process.env` variable, with much less leaking risks.


### PR DESCRIPTION
This API is available to see in the examples, but not written down in the documentation.