### PR TITLE
Add missing check for onChangeViewport in transition-manager

### DIFF
--- a/examples/deckgl-overlay/view.js
+++ b/examples/deckgl-overlay/view.js
@@ -103,7 +103,7 @@ export default class Example extends Component {
     }.bind(this), 2000);
   }
 
-  _onChangeViewport(opt) {
+  _onViewportChange(opt) {
     this.setState({viewport: opt});
   }
 
@@ -121,7 +121,7 @@ export default class Example extends Component {
       <InteractiveMap
         { ...viewport }
         maxPitch={85}
-        onViewportChange={ this._onChangeViewport }
+        onViewportChange={ this._onViewportChange }
         onClick={ this._onClickFeatures }
         // setting to `true` should cause the map to flicker because all sources
         // and layers need to be reloaded without diffing enabled.

--- a/examples/exhibit-browserify/app.js
+++ b/examples/exhibit-browserify/app.js
@@ -26,7 +26,7 @@ class Root extends Component {
       <MapGL
         {...viewport}
         mapStyle="mapbox://styles/mapbox/dark-v9"
-        onChangeViewport={v => this.setState({viewport: v})}
+        onViewportChange={v => this.setState({viewport: v})}
         preventStyleDiffing={false}
         mapboxApiAccessToken={MAPBOX_TOKEN}
         perspectiveEnabled

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -164,8 +164,10 @@ export default class TransitionManager {
     const mapState = new MapState(Object.assign({}, this.props, viewport));
     this.state.propsInTransition = mapState.getViewportProps();
 
-    if (this.props.onViewportChange) {
-      this.props.onViewportChange(this.state.propsInTransition);
+    // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
+    const onViewportChange = this.props.onViewportChange || this.props.onChangeViewport;
+    if (onViewportChange) {
+      onViewportChange(this.state.propsInTransition);
     }
 
     if (shouldEnd) {


### PR DESCRIPTION
Without this change if you do double click on map, zoom will have a delay and no transition.
looks like this change was missed in https://github.com/uber/react-map-gl/pull/259.

Note some examples use `onChangeViewport` which I guess should be updated.
