### PR TITLE
Support `onViewStateChange` in InteractiveMap and NavigationControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# Version 3.3.0-alpha.X
+- Add alternate interaction callback `onViewStateChange`
+
 # Version 3.3.0-alpha.4
 - Fix bug in handling deck.gl style `viewState` prop
 - Automatically load missing Mapbox stylesheet

--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -31,6 +31,19 @@ class Map extends Component {
 
 Has all properties of [StaticMap](/docs/components/static-map.md) and the following:
 
+##### `onViewStateChange` {Function}
+
+Callback that is fired when the user interacted with the map.
+
+`onViewStateChange({viewState})`
+
+The object passed to the callback contains viewport properties such as `longitude`, `latitude`, `zoom` etc.
+
+If the map is intended to be interactive, the app uses this prop to listen to map updates and update the props accordingly.
+
+Note:
+* `onViewStateChange` is a newer version of the `onViewportChange` callback. Both are supported and provide equivalent functionality.
+
 ##### `onViewportChange` {Function}
 
 Callback that is fired when the user interacted with the map.

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -25,11 +25,9 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
   // Min pitch in degrees
   minPitch: PropTypes.number,
 
-  /**
-   * `onViewportChange` callback is fired when the user interacted with the
-   * map. The object passed to the callback contains viewport properties
-   * such as `longitude`, `latitude`, `zoom` etc.
-   */
+  // Callbacks fired when the user interacted with the map. The object passed to the callbacks
+  // contains viewport properties such as `longitude`, `latitude`, `zoom` etc.
+  onViewStateChange: PropTypes.func,
   onViewportChange: PropTypes.func,
 
   /** Viewport transition **/
@@ -120,6 +118,7 @@ const getDefaultCursor = ({isDragging, isHovering}) => isDragging ?
 const defaultProps = Object.assign({},
   StaticMap.defaultProps, MAPBOX_LIMITS, TransitionManager.defaultProps,
   {
+    onViewStateChange: null,
     onViewportChange: null,
     onClick: null,
     onHover: null,
@@ -193,7 +192,7 @@ export default class InteractiveMap extends PureComponent {
     eventManager.on('mousemove', this._onMouseMove);
     eventManager.on('click', this._onMouseClick);
 
-    this._mapControls.setOptions(Object.assign({}, this.props, {
+    this._mapControls.setOptions(Object.assign({}, this.props, this.props.viewState, {
       onStateChange: this._onInteractiveStateChange,
       eventManager
     }));
@@ -202,7 +201,7 @@ export default class InteractiveMap extends PureComponent {
   }
 
   componentWillUpdate(nextProps) {
-    this._mapControls.setOptions(nextProps);
+    this._mapControls.setOptions(Object.assign({}, nextProps, nextProps.viewState));
     this._transitionManager.processViewportChange(nextProps);
   }
 

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -201,8 +201,9 @@ export default class InteractiveMap extends PureComponent {
   }
 
   componentWillUpdate(nextProps) {
-    this._mapControls.setOptions(Object.assign({}, nextProps, nextProps.viewState));
-    this._transitionManager.processViewportChange(nextProps);
+    const nextPropsWithViewState = Object.assign({}, nextProps, nextProps.viewState);
+    this._mapControls.setOptions(nextPropsWithViewState);
+    this._transitionManager.processViewportChange(nextPropsWithViewState);
   }
 
   getMap() {

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -14,12 +14,10 @@ const LINEAR_TRANSITION_PROPS = Object.assign({}, TransitionManager.defaultProps
 const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Custom className
   className: PropTypes.string,
-  /**
-    * `onViewportChange` callback is fired when the user interacted with the
-    * map. The object passed to the callback contains `latitude`,
-    * `longitude` and `zoom` and additional state information.
-    */
-  onViewportChange: PropTypes.func.isRequired,
+  // Callbacks fired when the user interacted with the map. The object passed to the callbacks
+  // contains viewport properties such as `longitude`, `latitude`, `zoom` etc.
+  onViewStateChange: PropTypes.func,
+  onViewportChange: PropTypes.func,
   // Show/hide compass button
   showCompass: PropTypes.bool,
   // Show/hide zoom buttons
@@ -28,6 +26,7 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 
 const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   className: '',
+  onViewStateChange: () => {},
   onViewportChange: () => {},
   showCompass: true,
   showZoom: true
@@ -59,11 +58,15 @@ export default class NavigationControl extends BaseControl {
   _updateViewport(opts) {
     const {viewport} = this.context;
     const mapState = new MapState(Object.assign({}, viewport, opts));
+    const viewState = Object.assign({}, mapState.getViewportProps(), LINEAR_TRANSITION_PROPS);
+
+    // Call new style callback
+    this.props.onViewStateChange({viewState});
+
+    // Call old style callback
     // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
     const onViewportChange = this.props.onChangeViewport || this.props.onViewportChange;
-    const newViewport = Object.assign({}, mapState.getViewportProps(), LINEAR_TRANSITION_PROPS);
-
-    onViewportChange(newViewport);
+    onViewportChange(viewState);
   }
 
   _onZoomIn() {

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -39,8 +39,8 @@ const propTypes = {
   visible: PropTypes.bool, /** Whether the map is visible */
 
   // Map view state
-  width: PropTypes.number.isRequired, /** The width of the map. */
-  height: PropTypes.number.isRequired, /** The height of the map. */
+  width: PropTypes.number, /** The width of the map. */
+  height: PropTypes.number, /** The height of the map. */
 
   viewState: PropTypes.object, /** object containing lng/lat/zoom/bearing/pitch */
 
@@ -70,7 +70,10 @@ const defaultProps = {
 
   bearing: 0,
   pitch: 0,
-  altitude: 1.5
+  altitude: 1.5,
+
+  width: 0,
+  height: 0
 };
 
 // Try to get access token from URL, env, local storage or config
@@ -278,12 +281,7 @@ export default class Mapbox {
       newViewState.altitude !== oldViewState.altitude;
 
     if (viewportChanged) {
-      this._map.jumpTo({
-        center: [newViewState.longitude, newViewState.latitude],
-        zoom: newViewState.zoom,
-        bearing: newViewState.bearing,
-        pitch: newViewState.pitch
-      });
+      this._map.jumpTo(this._getMapboxViewStateProps(newProps));
 
       // TODO - jumpTo doesn't handle altitude
       if (newViewState.altitude !== oldViewState.altitude) {
@@ -327,6 +325,18 @@ export default class Mapbox {
     } catch (error) {
       // do nothing
     }
+  }
+
+  _getMapboxViewStateProps(props) {
+    const viewState = this._getViewState(props);
+    return {
+      center: [viewState.longitude, viewState.latitude],
+      zoom: viewState.zoom,
+      bearing: viewState.bearing,
+      pitch: viewState.pitch,
+      width: props.width,
+      height: props.height
+    };
   }
 }
 

--- a/src/utils/map-controls.js
+++ b/src/utils/map-controls.js
@@ -115,9 +115,16 @@ export default class MapControls {
     const oldViewport = this.mapState ? this.mapState.getViewportProps() : {};
     const newViewport = Object.assign({}, newMapState.getViewportProps(), extraProps);
 
-    if (this.onViewportChange &&
-      Object.keys(newViewport).some(key => oldViewport[key] !== newViewport[key])) {
-      // Viewport has changed
+    const viewStateChanged =
+      Object.keys(newViewport).some(key => oldViewport[key] !== newViewport[key]);
+
+    // viewState has changed
+    if (viewStateChanged && this.onViewStateChange) {
+      this.onViewStateChange({viewState: newViewport});
+    }
+
+    // viewport has changed
+    if (viewStateChanged && this.onViewportChange) {
       this.onViewportChange(newViewport);
     }
 
@@ -138,6 +145,7 @@ export default class MapControls {
       // TODO(deprecate): remove this when `touchZoomRotate` gets deprecated
       touchZoomRotate = true,
 
+      onViewStateChange,
       onViewportChange,
       onStateChange = this.onStateChange,
       eventManager = this.eventManager,
@@ -150,6 +158,7 @@ export default class MapControls {
       keyboard = true
     } = options;
 
+    this.onViewStateChange = onViewStateChange;
     // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
     this.onViewportChange = onViewportChange || onChangeViewport;
     this.onStateChange = onStateChange;
@@ -166,7 +175,7 @@ export default class MapControls {
       this._events = {};
       this.toggleEvents(this.events, true);
     }
-    const isInteractive = Boolean(this.onViewportChange);
+    const isInteractive = Boolean(this.onViewStateChange || this.onViewportChange);
 
     // Register/unregister events
     this.toggleEvents(EVENT_TYPES.WHEEL, isInteractive && scrollZoom);

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -170,6 +170,10 @@ export default class TransitionManager {
       onViewportChange(this.state.propsInTransition);
     }
 
+    if (this.props.onViewStateChange) {
+      this.props.onViewStateChange({viewState: this.state.propsInTransition});
+    }
+
     if (shouldEnd) {
       this._endTransition();
       this.props.onTransitionEnd();


### PR DESCRIPTION
Enables significant alignment across DeckGL examples.