### PR TITLE
Fix captureClick in popup component

### DIFF
--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -45,13 +45,6 @@ const contextTypes = {
   eventManager: PropTypes.object
 };
 
-const EVENT_MAP = {
-  captureScroll: 'wheel',
-  captureDrag: 'panstart',
-  captureClick: 'click',
-  captureDoubleClick: 'dblclick'
-};
-
 /*
  * PureComponent doesn't update when context changes.
  * The only way is to implement our own shouldComponentUpdate here. Considering
@@ -87,16 +80,12 @@ export default class BaseControl extends Component {
 
     if (ref) {
       // container is mounted: register events for this element
-      events = {};
-
-      for (const propName in EVENT_MAP) {
-        const shouldCapture = this.props[propName];
-        const eventName = EVENT_MAP[propName];
-
-        if (shouldCapture) {
-          events[eventName] = this._captureEvent;
-        }
-      }
+      events = {
+        wheel: this._onScroll.bind(this),
+        panstart: this._onDrag.bind(this),
+        click: this._onClick.bind(this),
+        dblclick: this._onDoubleClick.bind(this)
+      };
 
       eventManager.on(events, ref);
     }
@@ -104,8 +93,28 @@ export default class BaseControl extends Component {
     this._events = events;
   }
 
-  _captureEvent(evt) {
-    evt.stopPropagation();
+  _onScroll(evt) {
+    if (this.props.captureScroll) {
+      evt.stopPropagation();
+    }
+  }
+
+  _onDrag(evt) {
+    if (this.props.captureDrag) {
+      evt.stopPropagation();
+    }
+  }
+
+  _onClick(evt) {
+    if (this.props.captureClick) {
+      evt.stopPropagation();
+    }
+  }
+
+  _onDoubleClick(evt) {
+    if (this.props.captureDoubleClick) {
+      evt.stopPropagation();
+    }
   }
 
   render() {

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -114,9 +114,11 @@ export default class Popup extends BaseControl {
    * event.
    */
   _onClick(evt) {
-    super._onClick(evt);
+    if (this.props.captureClick) {
+      evt.stopPropagation();
+    }
 
-    if (this._closeOnClick) {
+    if (this.props.closeOnClick || this._closeOnClick) {
       this.props.onClose();
     }
   }
@@ -157,7 +159,7 @@ export default class Popup extends BaseControl {
   }
 
   render() {
-    const {className, longitude, latitude, offsetLeft, offsetTop, closeOnClick} = this.props;
+    const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
 
     const [x, y] = this.context.viewport.project([longitude, latitude]);
 
@@ -174,8 +176,7 @@ export default class Popup extends BaseControl {
     return createElement('div', {
       className: `mapboxgl-popup mapboxgl-popup-anchor-${positionType} ${className}`,
       style: containerStyle,
-      ref: this._onContainerLoad,
-      onClick: closeOnClick ? this._onClose : null
+      ref: this._onContainerLoad
     }, [
       this._renderTip(),
       this._renderContent()

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -77,6 +77,8 @@ export default class Popup extends BaseControl {
     this._contentLoaded = this._contentLoaded.bind(this);
     this._renderTip = this._renderTip.bind(this);
     this._renderContent = this._renderContent.bind(this);
+
+    this._closeOnClick = false;
   }
 
   componentDidMount() {
@@ -102,8 +104,25 @@ export default class Popup extends BaseControl {
     return anchor;
   }
 
+  /*
+   * Hack -
+   * React's `onClick` is called before mjolnir.js' `click` event (aka `tap` from hammer.js)
+   * which has a configurable delay.
+   * If we close the popup on the React event, by the time `click` fires, this component will
+   * have been unmounted, thus `captureClick` will not work.
+   * Instead, we flag the popup as closed on the React event, and actually close it on the hammer.js
+   * event.
+   */
+  _onClick(evt) {
+    super._onClick(evt);
+
+    if (this._closeOnClick) {
+      this.props.onClose();
+    }
+  }
+
   _onClose() {
-    this.props.onClose();
+    this._closeOnClick = true;
   }
 
   _contentLoaded(ref) {


### PR DESCRIPTION
https://github.com/uber/react-map-gl/issues/304

- Handle `capture*` prop change
- Fix the issue where `captureClick` does not work on Popup components if click results in closing the popup