### PR TITLE
Enables extra options to be passed to mapbox-gl constructor. Fixes #545.

### DIFF
--- a/docs/components/static-map.md
+++ b/docs/components/static-map.md
@@ -115,6 +115,13 @@ Applications that frequently mount and unmount maps may try this prop to help wo
 A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
 Expected to return an object with a `url` property and optionally `headers` and `credentials` properties.  Equivalent to Mapbox's `transformRequest` [map option](https://www.mapbox.com/mapbox-gl-js/api#map).
 
+##### `mapOptions` {Object} - default: `{}`
+
+> Non-public API, see https://github.com/uber/react-map-gl/issues/545
+
+An object of additional options to be passed to Mapbox's [`Map` constructor](https://www.mapbox.com/mapbox-gl-js/api/#map). Options specified here
+will take precedence over those same options if set via props.
+
 ## Callbacks
 
 ##### `onLoad` {Function} - default: `no-op function`
@@ -143,4 +150,3 @@ Parameters:
 ## Source
 
 [static-map.js](https://github.com/uber/react-map-gl/tree/3.2-release/src/components/static-map.js)
-

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -51,7 +51,8 @@ const propTypes = {
   pitch: PropTypes.number, /** Specify the pitch of the viewport */
 
   // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-  altitude: PropTypes.number /** Altitude of the viewport camera. Default 1.5 "screen heights" */
+  altitude: PropTypes.number, /** Altitude of the viewport camera. Default 1.5 "screen heights" */
+  mapOptions: PropTypes.object /** Extra options to pass to Mapbox constructor. See #545. **/
 };
 
 const defaultProps = {
@@ -73,7 +74,9 @@ const defaultProps = {
   altitude: 1.5,
 
   width: 0,
-  height: 0
+  height: 0,
+
+  mapOptions: {}
 };
 
 // Try to get access token from URL, env, local storage or config
@@ -192,7 +195,9 @@ export default class Mapbox {
       if (props.transformRequest) {
         mapOptions.transformRequest = props.transformRequest;
       }
-      this._map = this.map = new props.mapboxgl.Map(mapOptions);
+      this._map = this.map = new props.mapboxgl.Map(
+        Object.assign({}, mapOptions, props.mapOptions));
+
       // Attach optional onLoad function
       this.map.once('load', props.onLoad);
       this.map.on('error', props.onError);


### PR DESCRIPTION
In some instances it's useful to be able to pass additional options to the Mapbox GL constructor — for instance, in [this particular project](https://ig.ft.com/gb-broadband-speed-map/) we put a lot of memory pressure on iPads and other high-res tablet devices and thus being able to specify `maxTileCacheSize` would have been helpful (as it is, we had to make a custom build of react-map-gl to access this functionality).

This adds a private API via props.mapOptions enabling such options to be passed to the Map constructor — I felt that making this a public API would be confusing in relation to the other props react-map-gl passes to Mapbox GL. As such I haven't written any tests or documentation — if, however, you think this should be a public API, do let me know and I'll do so.