### PR TITLE
Move map visibility check to StaticMap

### DIFF
--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -114,11 +114,6 @@ This object must implement the following interface:
 - `events` - An array of subscribed events
 - `handleEvent(event, context)` - A method that handles interactive events
 
-##### `visibilityConstraints` {Object} ==EXPERIMENTAL==
-
-An object with the bounding `minZoom`, `maxZoom`, `minPitch`, `maxPitch` within which the map should be visible. This will manage automatically toggling the
-`visible` prop in `StaticMap`.
-
 Parameters
 - `event` - The pointer event.
   + `event.lngLat` - The geo coordinates that is being hovered.

--- a/docs/components/static-map.md
+++ b/docs/components/static-map.md
@@ -122,6 +122,13 @@ Expected to return an object with a `url` property and optionally `headers` and 
 An object of additional options to be passed to Mapbox's [`Map` constructor](https://www.mapbox.com/mapbox-gl-js/api/#map). Options specified here
 will take precedence over those same options if set via props.
 
+##### `visibilityConstraints` {Object} ==EXPERIMENTAL==
+
+An object that specifies bounds for viewport props with `min*`, `max*` keys. If the viewport props are outside of these constraints, the Mapbox map is automatically hidden. 
+
+Default: `{ minZoom: 0, maxZoom: 20, minPitch: 0, maxPitch: 60 }`
+
+
 ## Callbacks
 
 ##### `onLoad` {Function} - default: `no-op function`

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -100,15 +100,6 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
   /** Accessor that returns a cursor style to show interactive state */
   getCursor: PropTypes.func,
 
-  /** Advanced features */
-  // Contraints for displaying the map. If not met, then the map is hidden.
-  // Experimental! May be changed in minor version updates.
-  visibilityConstraints: PropTypes.shape({
-    minZoom: PropTypes.number,
-    maxZoom: PropTypes.number,
-    minPitch: PropTypes.number,
-    maxPitch: PropTypes.number
-  }),
   // A map control instance to replace the default map controls
   // The object must expose one property: `events` as an array of subscribed
   // event names; and two methods: `setState(state)` and `handle(event)`
@@ -138,9 +129,7 @@ const defaultProps = Object.assign({},
 
     touchAction: 'none',
     clickRadius: 0,
-    getCursor: getDefaultCursor,
-
-    visibilityConstraints: MAPBOX_LIMITS
+    getCursor: getDefaultCursor
   }
 );
 
@@ -179,7 +168,6 @@ export default class InteractiveMap extends PureComponent {
 
     this.getMap = this.getMap.bind(this);
     this.queryRenderedFeatures = this.queryRenderedFeatures.bind(this);
-    this._checkVisibilityConstraints = this._checkVisibilityConstraints.bind(this);
     this._getFeatures = this._getFeatures.bind(this);
     this._onInteractiveStateChange = this._onInteractiveStateChange.bind(this);
     this._getPos = this._getPos.bind(this);
@@ -225,28 +213,6 @@ export default class InteractiveMap extends PureComponent {
 
   queryRenderedFeatures(geometry, options) {
     return this._map.queryRenderedFeatures(geometry, options);
-  }
-
-  // Checks a visibilityConstraints object to see if the map should be displayed
-  _checkVisibilityConstraints(props) {
-    const capitalize = s => s[0].toUpperCase() + s.slice(1);
-
-    const {visibilityConstraints} = props;
-    for (const propName in props) {
-      const capitalizedPropName = capitalize(propName);
-      const minPropName = `min${capitalizedPropName}`;
-      const maxPropName = `max${capitalizedPropName}`;
-
-      if (minPropName in visibilityConstraints &&
-        props[propName] < visibilityConstraints[minPropName]) {
-        return false;
-      }
-      if (maxPropName in visibilityConstraints &&
-        props[propName] > visibilityConstraints[maxPropName]) {
-        return false;
-      }
-    }
-    return true;
   }
 
   _getFeatures({pos, radius}) {
@@ -339,7 +305,6 @@ export default class InteractiveMap extends PureComponent {
         createElement(StaticMap, Object.assign({}, this.props,
           this._transitionManager && this._transitionManager.getViewportInTransition(),
           {
-            visible: this._checkVisibilityConstraints(this.props),
             ref: this._staticMapLoaded,
             children: this.props.children
           }

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -232,7 +232,8 @@ export default class StaticMap extends PureComponent {
     const {className, width, height, style, visibilityConstraints} = this.props;
     const mapContainerStyle = Object.assign({}, style, {width, height, position: 'relative'});
 
-    const visible = this.props.visible && checkVisibilityConstraints(this.props, visibilityConstraints);
+    const visible = this.props.visible &&
+      checkVisibilityConstraints(this.props.viewState || this.props, visibilityConstraints);
 
     const mapStyle = Object.assign({}, style, {
       width,

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -27,6 +27,7 @@ import WebMercatorViewport from 'viewport-mercator-project';
 
 import Mapbox from '../mapbox/mapbox';
 import isBrowser from '../utils/is-browser';
+import {checkVisibilityConstraints} from '../utils/map-constraints';
 
 const mapboxgl = isBrowser ? require('mapbox-gl') : null;
 
@@ -48,7 +49,12 @@ const propTypes = Object.assign({}, Mapbox.propTypes, {
   /** There are known issues with style diffing. As stopgap, add option to prevent style diffing. */
   preventStyleDiffing: PropTypes.bool,
   /** Whether the map is visible */
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+
+  /** Advanced features */
+  // Contraints for displaying the map. If not met, then the map is hidden.
+  // Experimental! May be changed in minor version updates.
+  visibilityConstraints: PropTypes.object
 });
 
 const defaultProps = Object.assign({}, Mapbox.defaultProps, {
@@ -223,8 +229,11 @@ export default class StaticMap extends PureComponent {
   }
 
   render() {
-    const {className, width, height, style, visible} = this.props;
+    const {className, width, height, style, visibilityConstraints} = this.props;
     const mapContainerStyle = Object.assign({}, style, {width, height, position: 'relative'});
+
+    const visible = this.props.visible && checkVisibilityConstraints(this.props, visibilityConstraints);
+
     const mapStyle = Object.assign({}, style, {
       width,
       height,

--- a/src/utils/map-constraints.js
+++ b/src/utils/map-constraints.js
@@ -1,0 +1,24 @@
+import {MAPBOX_LIMITS} from './map-state';
+
+function decapitalize(s) {
+  return s[0].toLowerCase() + s.slice(1);
+}
+
+// Checks a visibilityConstraints object to see if the map should be displayed
+// Returns true if props are within the constraints
+export function checkVisibilityConstraints(props, constraints = MAPBOX_LIMITS) {
+
+  for (const constraintName in constraints) {
+    // in the format of min* or max*
+    const type = constraintName.slice(0, 3);
+    const propName = decapitalize(constraintName.slice(3));
+
+    if (type === 'min' && props[propName] < constraints[constraintName]) {
+      return false;
+    }
+    if (type === 'max' && props[propName] > constraints[constraintName]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/test/src/utils/index.js
+++ b/test/src/utils/index.js
@@ -1,5 +1,6 @@
 import './transition';
 import './style-utils.spec';
 import './map-state.spec';
+import './map-constraints.spec';
 import './dynamic-position.spec';
 import './transition-manager.spec';

--- a/test/src/utils/map-constraints.spec.js
+++ b/test/src/utils/map-constraints.spec.js
@@ -1,0 +1,36 @@
+import test from 'tape-catch';
+import {checkVisibilityConstraints} from 'react-map-gl/utils/map-constraints';
+
+const TEST_CASES = [
+  {
+    props: {longitude: -122, latitude: 38, zoom: 10, pitch: 0, bearing: 0},
+    result: true
+  },
+  {
+    props: {longitude: -122, latitude: 38, zoom: 10, pitch: 70, bearing: 0},
+    result: false
+  },
+  {
+    props: {longitude: -122, latitude: 38, zoom: 10, pitch: 0, bearing: 0},
+    constraints: {minZoom: 0, maxZoom: 4},
+    result: false
+  },
+  {
+    props: {longitude: -122, latitude: 38, zoom: 1, pitch: 0, bearing: 0},
+    constraints: {minZoom: 4, maxZoom: 20},
+    result: false
+  },
+  {
+    props: {longitude: -122, latitude: 38, zoom: 10, pitch: 0, bearing: 0},
+    constraints: {minLongitude: -100},
+    result: false
+  }
+];
+
+test('checkVisibilityConstraints', t => {
+  TEST_CASES.forEach(testCase => {
+    t.is(checkVisibilityConstraints(testCase.props, testCase.constraints), testCase.result,
+      'Returns expected result');
+  });
+  t.end();
+});


### PR DESCRIPTION
Fixes deck.gl v6 use case: `<StaticMap>` may be passed zoom/pitch values that are not supported by Mapbox.