### PR TITLE
Upgrade Mapbox-GL-JS to 0.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-runtime": "^6.23.0",
     "bowser": "^1.2.0",
     "immutable": "*",
-    "mapbox-gl": "0.45",
+    "mapbox-gl": "0.47.0",
     "math.gl": "^2.0.0",
     "mjolnir.js": "^1.2.1",
     "prop-types": "^15.5.7",


### PR DESCRIPTION
Contains a bug fix where webpack and JS uglification cause runtime errors for Mapbox in production: https://github.com/mapbox/mapbox-gl-js/pull/6981
