### PR TITLE
Fix queryRenderedFeatures

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -20,7 +20,7 @@
 import {PureComponent, createElement} from 'react';
 import PropTypes from 'prop-types';
 
-import {getInteractiveLayerIds, setDiffStyle} from '../utils/style-utils';
+import {setDiffStyle} from '../utils/style-utils';
 import isImmutableMap from '../utils/is-immutable-map';
 
 import WebMercatorViewport from 'viewport-mercator-project';
@@ -87,7 +87,6 @@ export default class StaticMap extends PureComponent {
 
     this.getMap = this.getMap.bind(this);
     this.queryRenderedFeatures = this.queryRenderedFeatures.bind(this);
-    this._updateQueryParams = this._updateQueryParams.bind(this);
     this._updateMapSize = this._updateMapSize.bind(this);
     this._updateMapStyle = this._updateMapStyle.bind(this);
     this._mapboxMapLoaded = this._mapboxMapLoaded.bind(this);
@@ -111,7 +110,6 @@ export default class StaticMap extends PureComponent {
       mapStyle: isImmutableMap(mapStyle) ? mapStyle.toJS() : mapStyle
     }));
     this._map = this._mapbox.getMap();
-    this._updateQueryParams(mapStyle);
   }
 
   componentWillReceiveProps(newProps) {
@@ -151,20 +149,10 @@ export default class StaticMap extends PureComponent {
     * layer style to `true`.
     * @param {[Number, Number]|[[Number, Number], [Number, Number]]} geometry -
     *   Point or an array of two points defining the bounding box
-    * @param {Object} parameters - query options
+    * @param {Object} options - query options
     */
-  queryRenderedFeatures(geometry, parameters) {
-    const queryParams = parameters || this._queryParams;
-    if (queryParams.layers && queryParams.layers.length === 0) {
-      return [];
-    }
-    return this._map.queryRenderedFeatures(geometry, queryParams);
-  }
-
-  // Hover and click only query layers whose interactive property is true
-  _updateQueryParams(mapStyle) {
-    const interactiveLayerIds = getInteractiveLayerIds(mapStyle);
-    this._queryParams = {layers: interactiveLayerIds};
+  queryRenderedFeatures(geometry, options = {}) {
+    return this._map.queryRenderedFeatures(geometry, options);
   }
 
   // Note: needs to be called after render (e.g. in componentDidUpdate)
@@ -191,7 +179,6 @@ export default class StaticMap extends PureComponent {
       } else {
         this._map.setStyle(mapStyle);
       }
-      this._updateQueryParams(mapStyle);
     }
   }
 

--- a/src/utils/style-utils.js
+++ b/src/utils/style-utils.js
@@ -1,6 +1,8 @@
 import isImmutableMap from './is-immutable-map';
 import diffStyles from './diff-styles';
 
+// TODO - remove in the next major release
+// Mapbox dropped the `interactive` property: https://github.com/mapbox/mapbox-gl-js/issues/1479
 export function getInteractiveLayerIds(mapStyle) {
   let interactiveLayerIds = null;
 


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/558

#### Change list
- Do not overwrite query options when calling `queryRenderedFeatures`
- Move query parameters for `onHover` and `onClick` into `InteractiveMap`