### PR TITLE
Expose interaction state to callbacks

### DIFF
--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -31,29 +31,39 @@ class Map extends Component {
 
 Has all properties of [StaticMap](/docs/components/static-map.md) and the following:
 
-##### `onViewStateChange` {Function}
-
-Callback that is fired when the user interacted with the map.
-
-`onViewStateChange({viewState})`
-
-The object passed to the callback contains viewport properties such as `longitude`, `latitude`, `zoom` etc.
-
-If the map is intended to be interactive, the app uses this prop to listen to map updates and update the props accordingly.
-
-Note:
-* `onViewStateChange` is a newer version of the `onViewportChange` callback. Both are supported and provide equivalent functionality.
-
 ##### `onViewportChange` {Function}
 
 Callback that is fired when the user interacted with the map.
 
-`onViewportChange(viewState)`
+`onViewportChange(viewState, interactionState, oldViewState)`
 
-The object passed to the callback contains viewport properties such as `longitude`, `latitude`, `zoom` etc.
+Arguments: 
+
+- `viewState` {Object} The next viewport properties, including: `width`, `height`, `latitude`, `longitude`, `zoom`, `bearing`, `pitch`, `altitude`, `maxZoom`, `minZoom`, `maxPitch`, `minPitch`, `transitionDuration`, `transitionEasing`, `transitionInterpolator`, `transitionInterruption`.
+- `interactionState` {Object} Describes the interaction that caused this viewport change. May contain the following fields:
+  + `interactionState.isDragging` (Boolean)
+  + `interactionState.isPanning` (Boolean)
+  + `interactionState.isZooming` (Boolean)
+  + `interactionState.isRotating` (Boolean)
+- `oldViewState` {Object} The current viewport properties.
 
 Note:
-* Even if the newer `onViewStateChange` callback is supplied, the `onViewportChange` callback will still be called if supplied.
+* Even if both `onViewStateChange` and `onViewportChange` callbacks are supplied, they will both be called during an update.
+
+
+##### `onViewStateChange` {Function}
+
+Callback that is fired when the user interacted with the map.
+
+`onViewStateChange({viewState, interactionState, oldViewState})`
+
+If the map is intended to be interactive, the app uses this prop to listen to map updates and update the props accordingly.
+
+See `onViewportChange` for details of the arguments.
+
+Note:
+* `onViewStateChange` is a newer version of the `onViewportChange` callback. Both are supported and provide equivalent functionality.
+
 
 ##### `maxZoom` {Number} [default: 20]
 

--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -69,12 +69,9 @@ Possible fields include:
 
 - `interactionState.inTransition` (Boolean)
 - `interactionState.isDragging` (Boolean)
-- `interactionState.isPanning` (Boolean)
-- `interactionState.isZooming` (Boolean)
-- `interactionState.isRotating` (Boolean)
 
 Note:
-* `onInteractionStateChange` may be fired without `onViewportChange`. For example, when the pointer is released at the end of a drag-pan, `isDragging` and `isPanning` are reset to `false`, without the viewport's `longitude` and `latitude` changing.
+* `onInteractionStateChange` may be fired without `onViewportChange`. For example, when the pointer is released at the end of a drag-pan, `isDragging` are reset to `false`, without the viewport's `longitude` and `latitude` changing.
 
 
 ##### `maxZoom` {Number} [default: 20]

--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -31,29 +31,9 @@ class Map extends Component {
 
 Has all properties of [StaticMap](/docs/components/static-map.md) and the following:
 
-##### `onViewportChange` {Function}
-
-Callback that is fired when the user interacted with the map.
-
-`onViewportChange(viewState, interactionState, oldViewState)`
-
-Arguments: 
-
-- `viewState` {Object} The next viewport properties, including: `width`, `height`, `latitude`, `longitude`, `zoom`, `bearing`, `pitch`, `altitude`, `maxZoom`, `minZoom`, `maxPitch`, `minPitch`, `transitionDuration`, `transitionEasing`, `transitionInterpolator`, `transitionInterruption`.
-- `interactionState` {Object} Describes the interaction that caused this viewport change. May contain the following fields:
-  + `interactionState.isDragging` (Boolean)
-  + `interactionState.isPanning` (Boolean)
-  + `interactionState.isZooming` (Boolean)
-  + `interactionState.isRotating` (Boolean)
-- `oldViewState` {Object} The current viewport properties.
-
-Note:
-* Even if both `onViewStateChange` and `onViewportChange` callbacks are supplied, they will both be called during an update.
-
-
 ##### `onViewStateChange` {Function}
 
-Callback that is fired when the user interacted with the map.
+Callback that is fired when the map's viewport properties should be updated.
 
 `onViewStateChange({viewState, interactionState, oldViewState})`
 
@@ -63,6 +43,38 @@ See `onViewportChange` for details of the arguments.
 
 Note:
 * `onViewStateChange` is a newer version of the `onViewportChange` callback. Both are supported and provide equivalent functionality.
+
+##### `onViewportChange` {Function}
+
+Callback that is fired when the map's viewport properties should be updated.
+
+`onViewportChange(viewState, interactionState, oldViewState)`
+
+Arguments: 
+
+- `viewState` {Object} The next viewport properties, including: `width`, `height`, `latitude`, `longitude`, `zoom`, `bearing`, `pitch`, `altitude`, `maxZoom`, `minZoom`, `maxPitch`, `minPitch`, `transitionDuration`, `transitionEasing`, `transitionInterpolator`, `transitionInterruption`.
+- `interactionState` {Object} The current interaction that caused this viewport change. See `onInteractionStateChange` for possible fields.
+- `oldViewState` {Object} The current viewport properties.
+
+Note:
+* Even if both `onViewStateChange` and `onViewportChange` callbacks are supplied, they will both be called during an update.
+
+##### `onInteractionStateChange` {Function}
+
+Callback that is fired when the user interacted with the map.
+
+`onInteractionStateChange(interactionState)`
+
+Possible fields include:
+
+- `interactionState.inTransition` (Boolean)
+- `interactionState.isDragging` (Boolean)
+- `interactionState.isPanning` (Boolean)
+- `interactionState.isZooming` (Boolean)
+- `interactionState.isRotating` (Boolean)
+
+Note:
+* `onInteractionStateChange` may be fired without `onViewportChange`. For example, when the pointer is released at the end of a drag-pan, `isDragging` and `isPanning` are reset to `false`, without the viewport's `longitude` and `latitude` changing.
 
 
 ##### `maxZoom` {Number} [default: 20]

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -18,7 +18,9 @@ const DEFAULT_PROPS = {
   transitionInterruption: TRANSITION_EVENTS.BREAK,
   onTransitionStart: noop,
   onTransitionInterrupt: noop,
-  onTransitionEnd: noop
+  onTransitionEnd: noop,
+  onViewportChange: noop,
+  onStateChange: noop
 };
 
 const DEFAULT_STATE = {
@@ -137,6 +139,7 @@ export default class TransitionManager {
     };
 
     this._onTransitionFrame();
+    this.props.onStateChange({inTransition: true});
   }
 
   _onTransitionFrame() {
@@ -148,6 +151,7 @@ export default class TransitionManager {
   _endTransition() {
     cancelAnimationFrame(this.state.animation);
     this.state = DEFAULT_STATE;
+    this.props.onStateChange({inTransition: false});
   }
 
   _updateViewport() {
@@ -168,13 +172,7 @@ export default class TransitionManager {
     const mapState = new MapState(Object.assign({}, this.props, viewport));
     this.state.propsInTransition = mapState.getViewportProps();
 
-    if (this.props.onViewStateChange) {
-      this.props.onViewStateChange({
-        viewState: this.state.propsInTransition,
-        oldViewState: this.props,
-        interactionState: {inTransition: true}
-      });
-    }
+    this.props.onViewportChange(this.state.propsInTransition, {inTransition: true}, this.props);
 
     if (shouldEnd) {
       this._endTransition();

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -49,6 +49,10 @@ export default class TransitionManager {
     // Set this.props here as '_triggerTransition' calls '_updateViewport' that uses this.props.
     this.props = nextProps;
 
+    if (!currentProps) {
+      return false;
+    }
+
     // NOTE: Be cautious re-ordering statements in this function.
     if (this._shouldIgnoreViewportChange(currentProps, nextProps)) {
       return transitionTriggered;
@@ -164,14 +168,12 @@ export default class TransitionManager {
     const mapState = new MapState(Object.assign({}, this.props, viewport));
     this.state.propsInTransition = mapState.getViewportProps();
 
-    // TODO(deprecate): remove this check when `onChangeViewport` gets deprecated
-    const onViewportChange = this.props.onViewportChange || this.props.onChangeViewport;
-    if (onViewportChange) {
-      onViewportChange(this.state.propsInTransition);
-    }
-
     if (this.props.onViewStateChange) {
-      this.props.onViewStateChange({viewState: this.state.propsInTransition});
+      this.props.onViewStateChange({
+        viewState: this.state.propsInTransition,
+        oldViewState: this.props,
+        interactionState: {inTransition: true}
+      });
     }
 
     if (shouldEnd) {

--- a/test/src/utils/transition-manager.spec.js
+++ b/test/src/utils/transition-manager.spec.js
@@ -88,7 +88,7 @@ test('TransitionManager#callbacks', t => {
         'viewport matches end props');
       endCount++;
     },
-    onViewportChange: newViewport => {
+    onViewStateChange: ({viewState: newViewport}) => {
       t.ok(!transitionInterpolator.arePropsEqual(viewport, newViewport),
         'viewport has changed');
       viewport = newViewport;

--- a/test/src/utils/transition-manager.spec.js
+++ b/test/src/utils/transition-manager.spec.js
@@ -88,9 +88,10 @@ test('TransitionManager#callbacks', t => {
         'viewport matches end props');
       endCount++;
     },
-    onViewportChange: (newViewport) => {
+    onViewportChange: (newViewport, interactionState) => {
       t.ok(!transitionInterpolator.arePropsEqual(viewport, newViewport),
         'viewport has changed');
+      t.ok(interactionState.inTransition, 'inTransition flag is true');
       viewport = newViewport;
       // update props in transition, should not trigger interruption
       transitionManager.processViewportChange(Object.assign({}, transitionProps, viewport));

--- a/test/src/utils/transition-manager.spec.js
+++ b/test/src/utils/transition-manager.spec.js
@@ -88,7 +88,7 @@ test('TransitionManager#callbacks', t => {
         'viewport matches end props');
       endCount++;
     },
-    onViewStateChange: ({viewState: newViewport}) => {
+    onViewportChange: (newViewport) => {
       t.ok(!transitionInterpolator.arePropsEqual(viewport, newViewport),
         'viewport has changed');
       viewport = newViewport;


### PR DESCRIPTION
- add `onInteractionStateChange` callback
- expose interaction states (e.g. `isDragging`) to `onViewStateChange`/`onViewportChange` callbacks.