### PR TITLE
Fix npm start command for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "start": "(cd examples/main && (path-exists node_modules || npm i) && npm run start-local)",
+    "start": "(cd examples/main && (if [ ! -d 'node_modules' ]; then npm i; fi) && npm run start-local)",
     "build": "./scripts/build.sh && ./scripts/collect-metrics.sh",
     "preversion": "npm run test",
     "postversion": "git push && git push --tags",
@@ -63,7 +63,6 @@
     "immutable": "^3.8.2",
     "jsdom": "~9.9.1",
     "module-alias": "^2.0.0",
-    "path-exists": "^3.0.0",
     "pre-commit": "^1.2.2",
     "probe.gl": "^1.0.0-alpha.11",
     "puppeteer": "^1.2.0",


### PR DESCRIPTION
I might be missing something, but it seems like `npm start` in the root directory for development is flawed:

```
npm run start

> react-map-gl@3.3.0-alpha.5 start /Users/dschnurr/Uber/react-map-gl
> (cd examples/main && (path-exists node_modules || npm i) && npm run start-local)

sh: path-exists: command not found
```

Seems like it no longer looks for `path-exists` in root node_modules/.bin after the change directory command. It's probably easier to just use a bash folder existence check here instead of an npm package.