### PR TITLE
Add drag and drop support for Marker

### DIFF
--- a/docs/components/marker.md
+++ b/docs/components/marker.md
@@ -35,11 +35,35 @@ Offset of the marker from the left in pixels, negative number indicates left.
 ##### `offsetTop` {Number} - default: `0`
 Offset of the marker from the top in pixels, negative number indicates up.
 
+##### `draggable` {Boolean} - default `false`
+Allows this marker component to be dragged around the map. (Use `onDragEnd` to capture the final position and update `longitude` and `latitude`).
+
+##### `onDragStart` {Function}
+Called when a draggable marker starts being dragged.
+
+Parameters
+- `event` - The pointer event.
+  + `event.lngLat` - The geo coordinates where the drag started, as `[lng, lat]`.
+
+##### `onDrag` {Function}
+Continuously called while a draggable marker is being dragged.
+
+Parameters
+- `event` - The pointer event.
+  + `event.lngLat` - The geo coordinates of the drag event, as `[lng, lat]`.
+
+##### `onDragEnd` {Function}
+Called when a draggable marker is released at its final position. This is usually a good time to capture `event.lngLat` and update the marker's `longitude` and `latitude` props.
+
+Parameters
+- `event` - The pointer event.
+  + `event.lngLat` - The geo coordinates where the drag ended, as `[lng, lat]`.
+
 ##### `captureScroll` {Boolean} - default: `false`
 Stop propagation of mouse wheel event to the map component. Can be used to stop map from zooming when this component is scrolled.
 
 ##### `captureDrag` {Boolean} - default: `true`
-Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged.
+Stop propagation of dragstart event to the map component. Can be used to stop map from panning when this component is dragged. Automatically true if `draggable` is `true`.
 
 ##### `captureClick` {Boolean} - default: `true`
 Stop propagation of click event to the map component. Can be used to stop map from calling the `onClick` callback when this component is clicked.

--- a/examples/controls/src/city-pin.js
+++ b/examples/controls/src/city-pin.js
@@ -5,7 +5,6 @@ const ICON = `M20.2,15.7L20.2,15.7c1.1-1.6,1.8-3.6,1.8-5.7c0-5.6-4.5-10-10-10S2,
   C20.1,15.8,20.2,15.8,20.2,15.7z`;
 
 const pinStyle = {
-  cursor: 'pointer',
   fill: '#d00',
   stroke: 'none'
 };
@@ -16,9 +15,12 @@ export default class CityPin extends PureComponent {
     const {size = 20, onClick} = this.props;
 
     return (
-      <svg height={size} viewBox='0 0 24 24'
-        style={{...pinStyle, transform: `translate(${-size/2}px,${-size}px)`}}
-        onClick={onClick} >
+      <svg 
+        height={size}
+        viewBox="0 0 24 24"
+        style={{...pinStyle, transform: `translate(${-size / 2}px,${-size}px)`}}
+        onClick={onClick}
+      >
         <path d={ICON}/>
       </svg>
     );

--- a/examples/controls/src/control-panel.js
+++ b/examples/controls/src/control-panel.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 
-const defaultContainer =  ({children}) => <div className="control-panel">{children}</div>;
+const defaultContainer = ({children}) => <div className="control-panel">{children}</div>;
 
 export default class ControlPanel extends PureComponent {
   render() {

--- a/examples/draggable-markers/README.md
+++ b/examples/draggable-markers/README.md
@@ -1,0 +1,12 @@
+<div align="center">
+  <img src="https://avatars3.githubusercontent.com/u/2105791?v=3&s=200" />
+</div>
+
+## Example: Draggable Marker
+
+Demonstrates how Marker component can be dragged with react-map-gl.
+
+```
+    npm install
+    npm start
+```

--- a/examples/draggable-markers/app.css
+++ b/examples/draggable-markers/app.css
@@ -1,0 +1,20 @@
+body {
+  margin: 0;
+  background: #000;
+}
+
+.control-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  max-width: 320px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  padding: 12px 24px;
+  margin: 20px;
+  font-size: 13px;
+  line-height: 2;
+  color: #6b6b76;
+  text-transform: uppercase;
+  outline: none;
+}

--- a/examples/draggable-markers/index.html
+++ b/examples/draggable-markers/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>react-map-gl Draggable marker Example</title>
+    <link rel="stylesheet" type="text/css" href="app.css" />
+    <link rel="stylesheet" type="text/css" href="node_modules/mapbox-gl/dist/mapbox-gl.css" />
+  </head>
+  <body>
+    <script src='bundle.js'></script>
+  </body>
+</html>

--- a/examples/draggable-markers/package.json
+++ b/examples/draggable-markers/package.json
@@ -1,0 +1,20 @@
+{
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
+  },
+  "dependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-map-gl": "^3.2.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.18.0",
+    "webpack": "^2.4.0",
+    "webpack-dev-server": "^2.4.0"
+  }
+}

--- a/examples/draggable-markers/src/app.js
+++ b/examples/draggable-markers/src/app.js
@@ -4,10 +4,7 @@ import {render} from 'react-dom';
 import MapGL, {Marker, Popup, NavigationControl} from 'react-map-gl';
 
 import ControlPanel from './control-panel';
-import CityPin from './city-pin';
-import CityInfo from './city-info';
-
-import CITIES from '../../data/cities.json';
+import CityPin from '../../controls/src/city-pin';
 
 const TOKEN = ''; // Set your mapbox token here
 
@@ -32,7 +29,11 @@ export default class App extends Component {
         width: 500,
         height: 500,
       },
-      popupInfo: null
+      marker: {
+        latitude: 37.785164,
+        longitude: -100,
+      },
+      events: {}
     };
   }
 
@@ -59,34 +60,36 @@ export default class App extends Component {
     this.setState({viewport});
   }
 
-  _renderCityMarker = (city, index) => {
-    return (
-      <Marker 
-        key={`marker-${index}`}
-        longitude={city.longitude}
-        latitude={city.latitude} >
-        <CityPin size={20} onClick={() => this.setState({popupInfo: city})} />
-      </Marker>
-    );
+  _logDragEvent(name, event) {
+    this.setState({
+      events: {
+        ...this.state.events,
+        [name]: event.lngLat,
+      }
+    })
   }
 
-  _renderPopup() {
-    const {popupInfo} = this.state;
+  _onMarkerDragStart = (event) => {
+    this._logDragEvent('onDragStart', event);
+  };
 
-    return popupInfo && (
-      <Popup tipSize={5}
-        anchor="top"
-        longitude={popupInfo.longitude}
-        latitude={popupInfo.latitude}
-        onClose={() => this.setState({popupInfo: null})} >
-        <CityInfo info={popupInfo} />
-      </Popup>
-    );
-  }
+  _onMarkerDrag = (event) => {
+    this._logDragEvent('onDrag', event);
+  };
+
+  _onMarkerDragEnd = (event) => {
+    this._logDragEvent('onDragEnd', event);
+    this.setState({
+      marker: {
+        longitude: event.lngLat[0],
+        latitude: event.lngLat[1],
+      }
+    });
+  };
 
   render() {
 
-    const {viewport} = this.state;
+    const {viewport, marker} = this.state;
 
     return (
       <MapGL
@@ -94,17 +97,24 @@ export default class App extends Component {
         mapStyle="mapbox://styles/mapbox/dark-v9"
         onViewportChange={this._updateViewport}
         mapboxApiAccessToken={TOKEN} >
-
-        { CITIES.map(this._renderCityMarker) }
-
-        {this._renderPopup()}
+        <Marker 
+          longitude={marker.longitude}
+          latitude={marker.latitude}
+          draggable
+          onDragStart={this._onMarkerDragStart}
+          onDrag={this._onMarkerDrag}
+          onDragEnd={this._onMarkerDragEnd} >
+          <CityPin size={20} />
+        </Marker>
 
         <div className="nav" style={navStyle}>
           <NavigationControl onViewportChange={this._updateViewport} />
         </div>
 
-        <ControlPanel containerComponent={this.props.containerComponent} />
-
+        <ControlPanel
+          containerComponent={this.props.containerComponent}
+          events={this.state.events}
+        />
       </MapGL>
     );
   }

--- a/examples/draggable-markers/src/control-panel.js
+++ b/examples/draggable-markers/src/control-panel.js
@@ -1,0 +1,36 @@
+import React, {PureComponent} from 'react';
+
+const defaultContainer = ({children}) => <div className="control-panel">{children}</div>;
+
+const eventNames = ['onDragStart', 'onDrag', 'onDragEnd'];
+
+function round5(value) {
+  return (Math.round(value * 1e5) / 1e5).toFixed(5);
+}
+
+export default class ControlPanel extends PureComponent {
+  renderEvent = (eventName) => {
+    const {events = {}} = this.props;
+    const lngLat = events[eventName];
+    return (
+      <div>
+        <strong>{eventName}:</strong>{' '}
+        {lngLat ? lngLat.map(round5).join(', ') : <em>null</em>}
+      </div>
+    );
+  };
+
+  render() {
+    const Container = this.props.containerComponent || defaultContainer;
+    return (
+      <Container>
+        <h3>Draggable Marker</h3>
+        <p>Try dragging the marker to another location.</p>
+        <p>
+          {eventNames.map(this.renderEvent)}
+        </p>
+        {/* TODO add a "View Code" link here when we know the release */}
+      </Container>
+    );
+  }
+}

--- a/examples/draggable-markers/src/root.js
+++ b/examples/draggable-markers/src/root.js
@@ -1,0 +1,6 @@
+/* global document */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './app';
+
+ReactDOM.render(<App/>, document.body.appendChild(document.createElement('div')));

--- a/examples/draggable-markers/webpack.config.js
+++ b/examples/draggable-markers/webpack.config.js
@@ -1,0 +1,57 @@
+// NOTE: To use this example standalone (e.g. outside of repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
+const resolve = require('path').resolve;
+const webpack = require('webpack');
+
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
+const config = {
+  entry: {
+    app: resolve('./src/root.js')
+  },
+
+  devtool: 'source-map',
+
+  module: {
+    rules: [{
+      // Compile ES2015 using bable
+      test: /\.js$/,
+      include: [resolve('.')],
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
+    }]
+  },
+
+  resolve: {
+    alias: {
+      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
+      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
+    }
+  },
+
+  // Optional: Enables reading mapbox token from environment variable
+  plugins: [
+    new webpack.EnvironmentPlugin(['MapboxAccessToken'])
+  ]
+};
+
+// Enables bundling against src in this repo rather than the installed version
+module.exports = env => env && env.local ?
+  require('../webpack.config.local')(config)(env) : config;

--- a/examples/main/constants/toc.js
+++ b/examples/main/constants/toc.js
@@ -8,6 +8,7 @@ import ClickExample from '../views/click';
 // Standalone
 import Filter from '../../filter/src/app';
 import Controls from '../../controls/src/app';
+import DraggableMarker from '../../draggable-markers/src/app';
 import GeoJson from '../../geojson/src/app';
 import GeoJsonAnimation from '../../geojson-animation/src/app';
 import Interaction from '../../interaction/src/app';
@@ -30,6 +31,11 @@ export const standaloneExamples = [
     path: 'controlsExample',
     name: 'Markers & Popups',
     component: Controls
+  },
+  {
+    path: 'draggableMarkerExample',
+    name: 'Draggable Marker',
+    component: DraggableMarker
   },
   {
     path: 'geojsonExample',

--- a/examples/main/stylesheets/main.scss
+++ b/examples/main/stylesheets/main.scss
@@ -245,9 +245,6 @@ hr.short {
   bottom: 24px;
   color: $white-40;
 }
-.overlays {
-  cursor: crosshair;
-}
 
 @media screen and (max-width: 1200px) {
   .thumb {

--- a/ocular/src/mdRoutes.js
+++ b/ocular/src/mdRoutes.js
@@ -21,6 +21,11 @@ export default [
             component: require('../../examples/controls/src/app').default
           },
           {
+            path: 'draggableMarkerExample',
+            name: 'Draggable Marker',
+            component: require('../../examples/draggable-markers/src/app').default
+          },
+          {
             path: 'geojsonExample',
             name: 'GeoJSON',
             component: require('../../examples/geojson/src/app').default

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -58,11 +58,21 @@ export default class BaseControl extends Component {
     super(props);
 
     this._events = null;
+    this._containerRef = null;
 
     this._onContainerLoad = this._onContainerLoad.bind(this);
   }
 
+  componentWillUnmount() {
+    const {eventManager} = this.context;
+    if (eventManager && this._events) {
+      eventManager.off(this._events);
+    }
+  }
+
   _onContainerLoad(ref) {
+    this._containerRef = ref;
+
     const {eventManager} = this.context;
 
     // Return early if no eventManager is found
@@ -82,7 +92,7 @@ export default class BaseControl extends Component {
       // container is mounted: register events for this element
       events = {
         wheel: this._onScroll.bind(this),
-        panstart: this._onDrag.bind(this),
+        panstart: this._onDragStart.bind(this),
         click: this._onClick.bind(this),
         dblclick: this._onDoubleClick.bind(this)
       };
@@ -99,7 +109,7 @@ export default class BaseControl extends Component {
     }
   }
 
-  _onDrag(evt) {
+  _onDragStart(evt) {
     if (this.props.captureDrag) {
       evt.stopPropagation();
     }

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -31,7 +31,12 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Offset from the left
   offsetLeft: PropTypes.number,
   // Offset from the top
-  offsetTop: PropTypes.number
+  offsetTop: PropTypes.number,
+  // Drag and Drop props
+  draggable: PropTypes.bool,
+  onDrag: PropTypes.func,
+  onDragEnd: PropTypes.func,
+  onDragStart: PropTypes.func
 });
 
 const defaultProps = Object.assign({}, BaseControl.defaultProps, {
@@ -48,11 +53,131 @@ const defaultProps = Object.assign({}, BaseControl.defaultProps, {
  * recalculate the marker's position when the parent re-renders.
  */
 export default class Marker extends BaseControl {
+  constructor(props) {
+    super(props);
+    this.state = {
+      dragPos: null,
+      dragOffset: null
+    };
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount();
+    this._removeDragEvents();
+  }
+
+  _setupDragEvents() {
+    const {eventManager} = this.context;
+    if (!eventManager) {
+      return;
+    }
+
+    // panstart is already attached by parent class BaseControl,
+    // here we just add listeners for subsequent drag events
+    this._dragEvents = {
+      panmove: this._onDrag.bind(this),
+      panend: this._onDragEnd.bind(this),
+      pancancel: this._onDragCancel.bind(this)
+    };
+    eventManager.on(this._dragEvents);
+  }
+
+  _removeDragEvents() {
+    const {eventManager} = this.context;
+    if (!eventManager || !this._dragEvents) {
+      return;
+    }
+    eventManager.off(this._dragEvents);
+    this._dragEvents = null;
+  }
+
+  _getDragEventPosition(event) {
+    const {offsetCenter: {x, y}} = event;
+    return [x, y];
+  }
+
+  /**
+   * Returns offset of top-left of marker from drag start event
+   * (used for positioning marker relative to next mouse coordinates)
+   */
+  _getDragEventOffset(event) {
+    const {center: {x, y}} = event;
+    const rect = this._containerRef.getBoundingClientRect();
+    return [rect.left - x, rect.top - y];
+  }
+
+  _getDraggedMarkerPos(dragPos, dragOffset) {
+    return [
+      dragPos[0] + dragOffset[0],
+      dragPos[1] + dragOffset[1]
+    ];
+  }
+
+  _getDragLngLat(dragPos, dragOffset) {
+    return this.context.viewport.unproject(
+      this._getDraggedMarkerPos(dragPos, dragOffset)
+    );
+  }
+
+  _onDragStart(event) {
+    const {draggable, captureDrag} = this.props;
+    if (draggable || captureDrag) {
+      event.stopPropagation();
+    }
+    if (!draggable) {
+      return;
+    }
+
+    const dragPos = this._getDragEventPosition(event);
+    const dragOffset = this._getDragEventOffset(event);
+    this.setState({dragPos, dragOffset});
+    this._setupDragEvents();
+
+    if (this.props.onDragStart) {
+      event.lngLat = this._getDragLngLat(dragPos, dragOffset);
+      this.props.onDragStart(event);
+    }
+  }
+
+  _onDrag(event) {
+    event.stopPropagation();
+
+    const dragPos = this._getDragEventPosition(event);
+    this.setState({dragPos});
+
+    if (this.props.onDrag) {
+      event.lngLat = this._getDragLngLat(dragPos, this.state.dragOffset);
+      this.props.onDrag(event);
+    }
+  }
+
+  _onDragEnd(event) {
+    const {dragPos, dragOffset} = this.state;
+
+    event.stopPropagation();
+    this.setState({dragPos: null, dragOffset: null});
+    this._removeDragEvents();
+
+    if (this.props.onDragEnd) {
+      event.lngLat = this._getDragLngLat(dragPos, dragOffset);
+      this.props.onDragEnd(event);
+    }
+  }
+
+  _onDragCancel(event) {
+    event.stopPropagation();
+    this.setState({dragPos: null, dragOffset: null});
+    this._removeDragEvents();
+  }
 
   render() {
     const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
+    const {dragPos, dragOffset} = this.state;
 
-    const [x, y] = this.context.viewport.project([longitude, latitude]);
+    const [x, y] = dragPos ?
+      this._getDraggedMarkerPos(dragPos, dragOffset) :
+      this.context.viewport.project([longitude, latitude]);
+
     const containerStyle = {
       position: 'absolute',
       left: x + offsetLeft,

--- a/test/src/components/index.js
+++ b/test/src/components/index.js
@@ -1,1 +1,2 @@
 import './map.spec';
+import './marker.spec';

--- a/test/src/components/marker.spec.js
+++ b/test/src/components/marker.spec.js
@@ -1,0 +1,71 @@
+import PropTypes from 'prop-types';
+import {Marker} from 'react-map-gl';
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import WebMercatorViewport from 'viewport-mercator-project';
+import sinon from 'sinon';
+import test from 'tape-catch';
+
+function createMockContext() {
+  const viewport = new WebMercatorViewport({
+    width: 800,
+    height: 600,
+    longitude: -122.58,
+    latitude: 37.74,
+    zoom: 14
+  });
+  const eventManager = {
+    on: sinon.spy(),
+    off: sinon.spy()
+  };
+
+  class MockContext extends React.Component {
+    getChildContext() {
+      return {
+        viewport,
+        eventManager
+      };
+    }
+
+    render() {
+      return this.props.children;
+    }
+  }
+
+  MockContext.childContextTypes = {
+    viewport: PropTypes.instanceOf(WebMercatorViewport),
+    eventManager: PropTypes.object
+  };
+
+  MockContext.viewport = viewport;
+  MockContext.eventManager = eventManager;
+
+  return MockContext;
+}
+
+test('Marker#renders children', t => {
+  t.ok(Marker, 'Marker is defined');
+
+  const MockContext = createMockContext();
+
+  const tree = React.createElement(MockContext, {},
+    React.createElement(
+      Marker,
+      {
+        latitude: 37,
+        longitude: -122
+      },
+      React.createElement('div', {className: 'test-marker'}, ['hello'])
+    )
+  );
+
+  const result = ReactTestRenderer.create(tree);
+  const resultRoot = result.root;
+
+  t.ok(resultRoot.findByProps({className: 'mapboxgl-marker '}));
+  t.equal(resultRoot.findByProps({className: 'test-marker'}).children[0], 'hello');
+
+  result.unmount();
+
+  t.end();
+});

--- a/website/src/stylesheets/main.scss
+++ b/website/src/stylesheets/main.scss
@@ -191,9 +191,6 @@ hr.short {
   bottom: 24px;
   color: $white-40;
 }
-.overlays {
-  cursor: crosshair;
-}
 
 @media screen and (max-width: 576px) {
   .container {


### PR DESCRIPTION
> Resolves issue #483

This PR adds support for drag and drop events to the `<Marker>` component.

![kapture 2018-08-11 at 9 44 37](https://user-images.githubusercontent.com/875591/43994128-995fe8cc-9d4c-11e8-90a1-7d8d441e465f.gif)

Simply add a `draggable` prop to your Marker, and subscribe to whatever events you need:

```js
<Marker 
  longitude={marker.longitude}
  latitude={marker.latitude}
  draggable
  onDragStart={this._onMarkerDragStart}
  onDrag={this._onMarkerDrag}
  onDragEnd={this._onMarkerDragEnd}
>
  <Pin size={20} />
</Marker>
```

This API design is intended to be similar to [Mapbox's draggable markers](https://www.mapbox.com/mapbox-gl-js/example/drag-a-marker/).