### PR TITLE
Mapbox webpack resolver no longer needed in examples

### DIFF
--- a/examples/additional-overlays/webpack.config.js
+++ b/examples/additional-overlays/webpack.config.js
@@ -11,19 +11,12 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       loader: 'babel-loader',
       include: [resolve('.')],
       exclude: [/node_modules/]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/controls/webpack.config.js
+++ b/examples/controls/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/deckgl-overlay/webpack.config.js
+++ b/examples/deckgl-overlay/webpack.config.js
@@ -24,9 +24,7 @@ const config = {
       // Work against the latest base library in this repo
       'react-map-gl': resolve(LIB_DIR),
       // Ensure only one copy of react
-      react: resolve('./node_modules/react'),
-      // Per mapbox-gl-js README for non-browserify bundlers
-      'mapbox-gl$': resolve(`${LIB_DIR}/node_modules/mapbox-gl/dist/mapbox-gl.js`)
+      react: resolve('./node_modules/react')
     }
   },
 

--- a/examples/exhibit-webpack/webpack.config.js
+++ b/examples/exhibit-webpack/webpack.config.js
@@ -14,19 +14,12 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       loader: 'babel-loader',
       include: [resolve('.')],
       exclude: [/node_modules/]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/filter/webpack.config.js
+++ b/examples/filter/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/geojson-animation/webpack.config.js
+++ b/examples/geojson-animation/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/geojson/webpack.config.js
+++ b/examples/geojson/webpack.config.js
@@ -35,7 +35,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -44,13 +44,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/interaction/webpack.config.js
+++ b/examples/interaction/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/layers/webpack.config.js
+++ b/examples/layers/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/main/webpack.config.js
+++ b/examples/main/webpack.config.js
@@ -38,7 +38,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       exclude: [/node_modules/],
       use: [{

--- a/examples/reuse-map/webpack.config.js
+++ b/examples/reuse-map/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable

--- a/examples/viewport-animation/webpack.config.js
+++ b/examples/viewport-animation/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
 
   module: {
     rules: [{
-      // Compile ES2015 using bable
+      // Compile ES2015 using babel
       test: /\.js$/,
       include: [resolve('.')],
       exclude: [/node_modules/],
@@ -37,13 +37,6 @@ const config = {
         options: BABEL_CONFIG
       }]
     }]
-  },
-
-  resolve: {
-    alias: {
-      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
-    }
   },
 
   // Optional: Enables reading mapbox token from environment variable


### PR DESCRIPTION
Following Ib's comment in #121 about these webpack `resolve`s no longer being needed. I tested using the draggable marker example and it worked fine.