### PR TITLE
Add clarification to README around React vs WebGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ React Components Suite for <a href="https://github.com/mapbox/mapbox-gl-js">Mapb
 In addition to exposing MapboxGL functionality to React apps, react-map-gl also integrates seamlessly with [deck.gl](https://uber.github.io/deck.gl).
 
 ### Before You Begin
-This library provides convenient wrappers around initializing and (to some degree) tracking the state of a Mapbox WebGL map. However, because most of the functionality of Mapbox's JS API depends on the use of HTML5 canvases and WebGL, which React is not built to manipulate, this library is somewhat limited in the functionality that it exposes, and most implementation of Mapbox features and interactivity is better done with the [Mapbox API](https://www.mapbox.com/mapbox-gl-js/api/) exposed by the `getMap()` function in this library.
+This library provides convenient wrappers around initializing and (to some degree) tracking the state of a Mapbox WebGL map. However, because most of the functionality of Mapbox's JS API depends on the use of HTML5 canvases and WebGL, which React is not built to manipulate, the React component does not mirror all the functionality of Mapbox GL JS's Map class. You may access the native Mapbox API exposed by the `getMap()` function in this library. However, proceed with caution as calling the native APIs may break the connection between the React layer props and the underlying map state.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ React Components Suite for <a href="https://github.com/mapbox/mapbox-gl-js">Mapb
 
 In addition to exposing MapboxGL functionality to React apps, react-map-gl also integrates seamlessly with [deck.gl](https://uber.github.io/deck.gl).
 
+### Before You Begin
+This library provides convenient wrappers around initializing and (to some degree) tracking the state of a Mapbox WebGL map. However, because most of the functionality of Mapbox's JS API depends on the use of HTML5 canvases and WebGL, which React is not built to manipulate, this library is somewhat limited in the functionality that it exposes, and most implementation of Mapbox features and interactivity is better done with the [Mapbox API](https://www.mapbox.com/mapbox-gl-js/api/) exposed by the `getMap()` function in this library.
+
 ### Installation
 
 Using `react-map-gl` requires `node >= v4` and `react >= 15.4`.


### PR DESCRIPTION
## Motivation
I spent several days messing around with adding map markers through the Marker api, and then another few days trying to figure out how to get clustering working (see #507). After examining the underlying Mapbox API, I realized that the functionality exposed by `mapbox-gl-js` is much better suited to the work that I want to do than the primitives exposed by this library. I came to this library expecting a full React wrapper around `mapbox-gl-js`, which it isn't, and maybe shouldn't be, as that would require wrapping a bunch of imperative logic in React pseudocomponents using `componentDidMount` and `componentDidUpdate` and would be obnoxious to maintain.

That said, it would have been nice to have this understanding about a week ago, and adding a section to the readme could potentially provide that. I'm open to feedback on wording and placement.