### PR TITLE
Upgrade to new React context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "webworkify-webpack-dropin": "^1.1.9"
   },
   "peerDependencies": {
-    "react": ">=15.4.x"
+    "react": ">=16.3.0"
   },
   "engines": {
     "node": ">= 4",

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -52,13 +52,13 @@ export default class BaseControl extends PureComponent {
   constructor(props) {
     super(props);
 
-    this.context = {};
+    this._context = {};
     this._events = null;
     this._containerRef = null;
   }
 
   componentWillUnmount() {
-    const {eventManager} = this.context;
+    const {eventManager} = this._context;
     if (eventManager && this._events) {
       eventManager.off(this._events);
     }
@@ -67,7 +67,7 @@ export default class BaseControl extends PureComponent {
   _onContainerLoad = (ref) => {
     this._containerRef = ref;
 
-    const {eventManager} = this.context;
+    const {eventManager} = this._context;
 
     // Return early if no eventManager is found
     if (!eventManager) {
@@ -121,7 +121,7 @@ export default class BaseControl extends PureComponent {
     }
   }
 
-  _render(context) {
+  _render() {
     throw new Error('_render() not implemented');
   }
 
@@ -132,7 +132,7 @@ export default class BaseControl extends PureComponent {
           // Save event manager
           return createElement(StaticContext.Consumer, null,
             (staticContext) => {
-              this.context = {...interactiveContext, ...staticContext};
+              this._context = {...interactiveContext, ...staticContext};
               return this._render();
             }
           );

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -17,9 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {Component} from 'react';
+import {PureComponent, createElement} from 'react';
 import PropTypes from 'prop-types';
-import WebMercatorViewport from 'viewport-mercator-project';
+import {InteractiveContext} from './interactive-map';
+import {StaticContext} from './static-map';
 
 const propTypes = {
   /** Event handling */
@@ -39,12 +40,6 @@ const defaultProps = {
   captureDoubleClick: true
 };
 
-const contextTypes = {
-  viewport: PropTypes.instanceOf(WebMercatorViewport),
-  isDragging: PropTypes.bool,
-  eventManager: PropTypes.object
-};
-
 /*
  * PureComponent doesn't update when context changes.
  * The only way is to implement our own shouldComponentUpdate here. Considering
@@ -52,11 +47,12 @@ const contextTypes = {
  * is almost always triggered by a viewport change, we almost definitely need to
  * recalculate the marker's position when the parent re-renders.
  */
-export default class BaseControl extends Component {
+export default class BaseControl extends PureComponent {
 
   constructor(props) {
     super(props);
 
+    this.context = {};
     this._events = null;
     this._containerRef = null;
   }
@@ -125,12 +121,26 @@ export default class BaseControl extends Component {
     }
   }
 
-  render() {
-    return null;
+  _render(context) {
+    throw new Error('_render() not implemented');
   }
 
+  render() {
+    return (
+      createElement(InteractiveContext.Consumer, null,
+        (interactiveContext) => {
+          // Save event manager
+          return createElement(StaticContext.Consumer, null,
+            (staticContext) => {
+              this.context = {...interactiveContext, ...staticContext};
+              return this._render();
+            }
+          );
+        }
+      )
+    );
+  }
 }
 
 BaseControl.propTypes = propTypes;
 BaseControl.defaultProps = defaultProps;
-BaseControl.contextTypes = contextTypes;

--- a/src/components/draggable-control.js
+++ b/src/components/draggable-control.js
@@ -46,7 +46,7 @@ export default class DraggableControl extends BaseControl {
   }
 
   _setupDragEvents() {
-    const {eventManager} = this.context;
+    const {eventManager} = this._context;
     if (!eventManager) {
       return;
     }
@@ -62,7 +62,7 @@ export default class DraggableControl extends BaseControl {
   }
 
   _removeDragEvents() {
-    const {eventManager} = this.context;
+    const {eventManager} = this._context;
     if (!eventManager || !this._dragEvents) {
       return;
     }
@@ -93,7 +93,7 @@ export default class DraggableControl extends BaseControl {
   }
 
   _getDragLngLat(dragPos, dragOffset) {
-    return this.context.viewport.unproject(
+    return this._context.viewport.unproject(
       this._getDraggedPosition(dragPos, dragOffset)
     );
   }

--- a/src/components/draggable-control.js
+++ b/src/components/draggable-control.js
@@ -149,10 +149,6 @@ export default class DraggableControl extends BaseControl {
     this._removeDragEvents();
   }
 
-  render() {
-    return null;
-  }
-
 }
 
 DraggableControl.propTypes = propTypes;

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -1,4 +1,4 @@
-import {PureComponent, createElement} from 'react';
+import {PureComponent, createElement, createContext} from 'react';
 import PropTypes from 'prop-types';
 
 import StaticMap from './static-map';
@@ -12,6 +12,11 @@ import {EventManager} from 'mjolnir.js';
 import MapControls from '../utils/map-controls';
 import config from '../config';
 import deprecateWarn from '../utils/deprecate-warn';
+
+export const InteractiveContext = createContext({
+  eventManager: null,
+  isDragging: false
+});
 
 const propTypes = Object.assign({}, StaticMap.propTypes, {
   // Additional props on top of StaticMap
@@ -135,12 +140,6 @@ const defaultProps = Object.assign({},
   }
 );
 
-const childContextTypes = {
-  viewport: PropTypes.instanceOf(WebMercatorViewport),
-  isDragging: PropTypes.bool,
-  eventManager: PropTypes.object
-};
-
 export default class InteractiveMap extends PureComponent {
 
   static supported() {
@@ -169,14 +168,6 @@ export default class InteractiveMap extends PureComponent {
     });
 
     this._updateQueryParams(props.mapStyle);
-  }
-
-  getChildContext() {
-    return {
-      viewport: new WebMercatorViewport(this.props),
-      isDragging: this.state.isDragging,
-      eventManager: this._eventManager
-    };
   }
 
   componentDidMount() {
@@ -324,8 +315,12 @@ export default class InteractiveMap extends PureComponent {
       position: 'relative',
       cursor: getCursor(this.state)
     };
+    const interactiveContext = {
+      isDragging: this.state.isDragging,
+      eventManager: this._eventManager
+    };
 
-    return (
+    return createElement(InteractiveContext.Provider, {value: interactiveContext},
       createElement('div', {
         key: 'map-controls',
         ref: this._eventCanvasLoaded,
@@ -345,4 +340,3 @@ export default class InteractiveMap extends PureComponent {
 InteractiveMap.displayName = 'InteractiveMap';
 InteractiveMap.propTypes = propTypes;
 InteractiveMap.defaultProps = defaultProps;
-InteractiveMap.childContextTypes = childContextTypes;

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -59,7 +59,7 @@ export default class Marker extends DraggableControl {
 
     const [x, y] = dragPos ?
       this._getDraggedPosition(dragPos, dragOffset) :
-      this.context.viewport.project([longitude, latitude]);
+      this._context.viewport.project([longitude, latitude]);
 
     const containerStyle = {
       position: 'absolute',

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -53,7 +53,7 @@ const defaultProps = Object.assign({}, DraggableControl.defaultProps, {
  * recalculate the marker's position when the parent re-renders.
  */
 export default class Marker extends DraggableControl {
-  render() {
+  _render() {
     const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
     const {dragPos, dragOffset} = this.state;
 

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -44,10 +44,6 @@ export default class NavigationControl extends BaseControl {
     deprecateWarn(props);
   }
 
-  shouldComponentUpdate(nextProps, nextState, nextContext) {
-    return this.context.viewport.bearing !== nextContext.viewport.bearing;
-  }
-
   _updateViewport(opts) {
     const {viewport} = this.context;
     const mapState = new MapState(Object.assign({}, viewport, opts));
@@ -93,8 +89,7 @@ export default class NavigationControl extends BaseControl {
     });
   }
 
-  render() {
-
+  _render() {
     const {className, showCompass, showZoom} = this.props;
 
     return createElement('div', {

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -45,7 +45,7 @@ export default class NavigationControl extends BaseControl {
   }
 
   _updateViewport(opts) {
-    const {viewport} = this.context;
+    const {viewport} = this._context;
     const mapState = new MapState(Object.assign({}, viewport, opts));
     const viewState = Object.assign({}, mapState.getViewportProps(), LINEAR_TRANSITION_PROPS);
 
@@ -59,11 +59,11 @@ export default class NavigationControl extends BaseControl {
   }
 
   _onZoomIn = () => {
-    this._updateViewport({zoom: this.context.viewport.zoom + 1});
+    this._updateViewport({zoom: this._context.viewport.zoom + 1});
   }
 
   _onZoomOut = () => {
-    this._updateViewport({zoom: this.context.viewport.zoom - 1});
+    this._updateViewport({zoom: this._context.viewport.zoom - 1});
   }
 
   _onResetNorth = () => {
@@ -71,7 +71,7 @@ export default class NavigationControl extends BaseControl {
   }
 
   _renderCompass() {
-    const {bearing} = this.context.viewport;
+    const {bearing} = this._context.viewport;
     return createElement('span', {
       className: 'mapboxgl-ctrl-compass-arrow',
       style: {transform: `rotate(${bearing}deg)`}

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -152,7 +152,7 @@ export default class Popup extends BaseControl {
     ]);
   }
 
-  render() {
+  _render() {
     const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
 
     const [x, y] = this.context.viewport.project([longitude, latitude]);

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -81,7 +81,7 @@ export default class Popup extends BaseControl {
   }
 
   _getPosition(x, y) {
-    const {viewport} = this.context;
+    const {viewport} = this._context;
     const {anchor, dynamicPosition, tipSize} = this.props;
 
     if (this._content) {
@@ -155,7 +155,7 @@ export default class Popup extends BaseControl {
   _render() {
     const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
 
-    const [x, y] = this.context.viewport.project([longitude, latitude]);
+    const [x, y] = this._context.viewport.project([longitude, latitude]);
 
     const positionType = this._getPosition(x, y);
     const anchorPosition = ANCHOR_POSITION[positionType];

--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {PureComponent, createElement} from 'react';
+import {PureComponent, createElement, createContext} from 'react';
 import PropTypes from 'prop-types';
 
 import {normalizeStyle} from '../utils/style-utils';
@@ -32,6 +32,10 @@ import {checkVisibilityConstraints} from '../utils/map-constraints';
 const TOKEN_DOC_URL = 'https://uber.github.io/react-map-gl/#/Documentation/getting-started/about-mapbox-tokens';
 const NO_TOKEN_WARNING = 'A valid API access token is required to use Mapbox data';
 /* eslint-disable max-len */
+
+export const StaticContext = createContext({
+  viewport: null
+});
 
 function noop() {}
 
@@ -62,10 +66,6 @@ const defaultProps = Object.assign({}, Mapbox.defaultProps, {
   visible: true
 });
 
-const childContextTypes = {
-  viewport: PropTypes.instanceOf(WebMercatorViewport)
-};
-
 export default class StaticMap extends PureComponent {
   static supported() {
     return mapboxgl && mapboxgl.supported();
@@ -82,12 +82,6 @@ export default class StaticMap extends PureComponent {
     }
     this.state = {
       accessTokenInvalid: false
-    };
-  }
-
-  getChildContext() {
-    return {
-      viewport: new WebMercatorViewport(this.props)
     };
   }
 
@@ -218,9 +212,11 @@ export default class StaticMap extends PureComponent {
       height,
       overflow: 'hidden'
     };
+    const staticContext = {
+      viewport: new WebMercatorViewport(this.props)
+    };
 
-    // Note: a static map still handles clicks and hover events
-    return (
+    return createElement(StaticContext.Provider, {value: staticContext},
       createElement('div', {
         key: 'map-container',
         style: mapContainerStyle,
@@ -233,7 +229,6 @@ export default class StaticMap extends PureComponent {
           }),
           createElement('div', {
             key: 'map-overlays',
-            // Same as interactive map's overlay container
             className: 'overlays',
             style: overlayContainerStyle,
             children: this.props.children
@@ -248,4 +243,3 @@ export default class StaticMap extends PureComponent {
 StaticMap.displayName = 'StaticMap';
 StaticMap.propTypes = propTypes;
 StaticMap.defaultProps = defaultProps;
-StaticMap.childContextTypes = childContextTypes;

--- a/src/overlays/canvas-overlay.js
+++ b/src/overlays/canvas-overlay.js
@@ -72,7 +72,7 @@ export default class CanvasOverlay extends BaseControl {
     this._onContainerLoad(ref);
   }
 
-  render() {
+  _render() {
     const pixelRatio = window.devicePixelRatio || 1;
     const {viewport: {width, height}} = this.context;
 

--- a/src/overlays/canvas-overlay.js
+++ b/src/overlays/canvas-overlay.js
@@ -54,7 +54,7 @@ export default class CanvasOverlay extends BaseControl {
     ctx.save();
     ctx.scale(pixelRatio, pixelRatio);
 
-    const {viewport, isDragging} = this.context;
+    const {viewport, isDragging} = this._context;
     this.props.redraw({
       width: viewport.width,
       height: viewport.height,
@@ -74,7 +74,7 @@ export default class CanvasOverlay extends BaseControl {
 
   _render() {
     const pixelRatio = window.devicePixelRatio || 1;
-    const {viewport: {width, height}} = this.context;
+    const {viewport: {width, height}} = this._context;
 
     return (
       createElement('canvas', {

--- a/src/overlays/html-overlay.js
+++ b/src/overlays/html-overlay.js
@@ -36,7 +36,7 @@ const defaultProps = {
 
 export default class HTMLOverlay extends BaseControl {
   _render() {
-    const {viewport, isDragging} = this.context;
+    const {viewport, isDragging} = this._context;
     const style = Object.assign({
       position: 'absolute',
       left: 0,

--- a/src/overlays/html-overlay.js
+++ b/src/overlays/html-overlay.js
@@ -35,7 +35,7 @@ const defaultProps = {
 };
 
 export default class HTMLOverlay extends BaseControl {
-  render() {
+  _render() {
     const {viewport, isDragging} = this.context;
     const style = Object.assign({
       position: 'absolute',

--- a/src/overlays/svg-overlay.js
+++ b/src/overlays/svg-overlay.js
@@ -36,7 +36,7 @@ const defaultProps = {
 
 export default class SVGOverlay extends BaseControl {
   _render() {
-    const {viewport, isDragging} = this.context;
+    const {viewport, isDragging} = this._context;
     const style = Object.assign({
       position: 'absolute',
       left: 0,

--- a/src/overlays/svg-overlay.js
+++ b/src/overlays/svg-overlay.js
@@ -35,7 +35,7 @@ const defaultProps = {
 };
 
 export default class SVGOverlay extends BaseControl {
-  render() {
+  _render() {
     const {viewport, isDragging} = this.context;
     const style = Object.assign({
       position: 'absolute',


### PR DESCRIPTION
React plans to remove the legacy context API in v17: https://reactjs.org/docs/context.html

Note: additional-overlay example is broken, will fix in a follow up PR.

@XiaokaiUber 