### PR TITLE
Bug fixes for auto-resize mode

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -282,7 +282,10 @@ export default class InteractiveMap extends PureComponent {
       }
 
       if (this.props.onHover) {
-        const viewport = new WebMercatorViewport(this.props);
+        const viewport = new WebMercatorViewport(Object.assign({}, this.props, {
+          width: this._width,
+          height: this._height
+        }));
         event.lngLat = viewport.unproject(pos);
         event.features = features;
 
@@ -294,7 +297,10 @@ export default class InteractiveMap extends PureComponent {
   _onMouseClick = (event) => {
     if (this.props.onClick) {
       const pos = this._getPos(event);
-      const viewport = new WebMercatorViewport(this.props);
+      const viewport = new WebMercatorViewport(Object.assign({}, this.props, {
+        width: this._width,
+        height: this._height
+      }));
       event.lngLat = viewport.unproject(pos);
       event.features = this._getFeatures({pos, radius: this.props.clickRadius});
 

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -149,10 +149,9 @@ export default class Mapbox {
   // (e.g. until "componentDidUpdate")
   resize() {
     this._map.resize();
-    try {
+    // map render will throw error if style is not loaded
+    if (this._map.isStyleLoaded()) {
       this._map._render();
-    } catch (error) {
-      // this may happen if resize() is called before map style is loaded
     }
     return this;
   }

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -149,7 +149,11 @@ export default class Mapbox {
   // (e.g. until "componentDidUpdate")
   resize() {
     this._map.resize();
-    this._map._render();
+    try {
+      this._map._render();
+    } catch (error) {
+      // this may happen if resize() is called before map style is loaded
+    }
     return this;
   }
 


### PR DESCRIPTION
- Fix: onHover and onClick errors if width/height are not numbers
- Fix: `mapbox.resize()` error before map is loaded