### PR TITLE
[v4.0] Add interaction callbacks

### DIFF
--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -29,53 +29,58 @@ class Map extends Component {
 
 ## Properties
 
-Has all properties of [StaticMap](/docs/components/static-map.md) and the following:
+### Initialization
 
-##### `onViewStateChange` {Function}
+Inherit the following props from [StaticMap](/docs/components/static-map.md):
 
-Callback that is fired when the map's viewport properties should be updated.
+- `attributionControl` {Bool}
+- `disableTokenWarning` {Bool}
+- `gl` {WebGLContext}
+- `mapboxApiAccessToken` {String}
+- `mapOptions` {Object}
+- `preserveDrawingBuffer` {Bool}
+- `preventStyleDiffing` {Bool}
+- `reuseMaps` {Bool}
+- `transformRequest` {Function}
 
-`onViewStateChange({viewState, interactionState, oldViewState})`
 
-If the map is intended to be interactive, the app uses this prop to listen to map updates and update the props accordingly.
+### Map State
 
-See `onViewportChange` for details of the arguments.
+Inherit the following props from [StaticMap](/docs/components/static-map.md):
 
-Note:
-* `onViewStateChange` is a newer version of the `onViewportChange` callback. Both are supported and provide equivalent functionality.
+- `mapStyle` {String | Object | Immutable.Map}
+- `width` {Number | String} (required)
+- `height` {Number | String} (required)
+- `latitude` {Number}
+- `longitude` {Number}
+- `zoom` {Number}
+- `bearing` {Number} - default: `0`
+- `pitch` {Number} - default: `0`
+- `altitude` {Number} - default: `1.5 (screen heights)`
+- `viewState` {Object}
 
-##### `onViewportChange` {Function}
 
-Callback that is fired when the map's viewport properties should be updated.
+### Render Options
 
-`onViewportChange(viewState, interactionState, oldViewState)`
+Inherit the following props from [StaticMap](/docs/components/static-map.md):
 
-Arguments: 
+- `style` {Object}
+- `visible` {Bool}
+- `visibilityConstraints`
 
-- `viewState` {Object} The next viewport properties, including: `width`, `height`, `latitude`, `longitude`, `zoom`, `bearing`, `pitch`, `altitude`, `maxZoom`, `minZoom`, `maxPitch`, `minPitch`, `transitionDuration`, `transitionEasing`, `transitionInterpolator`, `transitionInterruption`.
-- `interactionState` {Object} The current interaction that caused this viewport change. See `onInteractionStateChange` for possible fields.
-- `oldViewState` {Object} The current viewport properties.
+##### `getCursor` {Function}
 
-Note:
-* Even if both `onViewStateChange` and `onViewportChange` callbacks are supplied, they will both be called during an update.
+Accessor that returns a cursor style to show interactive state. Called when the component is being rendered.
 
-##### `onInteractionStateChange` {Function}
+Parameters
+- `state` - The current state of the component.
+  + `state.isDragging` - If the map is being dragged.
+  + `state.isHovering` - If the pointer is over an interactive feature. See `interactiveLayerIds` prop.
 
-Callback that is fired when the user interacted with the map.
+The default implementation of `getCursor` returns `'pointer'` if `isHovering`, `'grabbing'` if `isDragging` and `'grab'` otherwise.
 
-`onInteractionStateChange(interactionState)`
 
-Possible fields include:
-
-- `interactionState.inTransition` (Boolean)
-- `interactionState.isDragging` (Boolean)
-- `interactionState.isPanning` (Boolean)
-- `interactionState.isRotating` (Boolean)
-- `interactionState.isZooming` (Boolean)
-
-Note:
-* `onInteractionStateChange` may be fired without `onViewportChange`. For example, when the pointer is released at the end of a drag-pan, `isDragging` are reset to `false`, without the viewport's `longitude` and `latitude` changing.
-
+### Interaction Options
 
 ##### `maxZoom` {Number} [default: 20]
 
@@ -146,44 +151,8 @@ If not specified:
 - Pointer event callbacks will query the features under the pointer of all layers.
 - The `getCursor` callback will always receive `isHovering: false`.
 
-##### `onHover` {Function}
 
-Called when the map is hovered over.
-
-Parameters
-- `event` - The pointer event.
-  + `event.lngLat` - The geo coordinates that is being clicked.
-  + `event.features` - The array of features under the pointer, queried using Mapbox's
-    [queryRenderedFeatures](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures) API.
-    To make only selected layers interactive, set the `interactiveLayerIds` prop.
-
-##### `onClick` {Function}
-
-Called when the map is clicked.
-
-Parameters
-- `event` - The pointer event.
-  + `event.lngLat` - The geo coordinates that is being clicked.
-  + `event.features` - The array of features under the pointer, queried using Mapbox's
-    [queryRenderedFeatures](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures) API.
-    To make only selected layers interactive, set the `interactiveLayerIds` prop.
-
-##### `onContextMenu` {Function}
-
-Called when the context menu is activated. Prevent default here to enable right button interaction.
-
-Default: `event => event.preventDefault()`
-
-##### `getCursor` {Function}
-
-Accessor that returns a cursor style to show interactive state. Called when the component is being rendered.
-
-Parameters
-- `state` - The current state of the component.
-  + `state.isDragging` - If the map is being dragged.
-  + `state.isHovering` - If the pointer is over an interactive feature. See `interactiveLayerIds` prop.
-
-The default implementation of `getCursor` returns `'pointer'` if `isHovering`, `'grabbing'` if `isDragging` and `'grab'` otherwise.
+### Transitions
 
 ##### `transitionDuration` {Number}
 
@@ -218,9 +187,122 @@ What to do if an ongoing transition is interrupted by another transition. There 
 - `TRANSITION_EVENTS.IGNORE` - Complete the previous transition and ignore the new viewport change.
 
 You may import the constants as follows:
-```
+
+```js
 import {TRANSITION_EVENTS} from 'react-map-gl';
 ```
+
+
+### Callbacks
+
+Inherit the following props from [StaticMap](/docs/components/static-map.md):
+
+- `onLoad` {Function}
+- `onResize` {Function}
+- `onError` {Function}
+
+
+##### `onViewportChange` {Function}
+
+Callback that is fired when the map's viewport properties should be updated.
+
+```js
+onViewportChange(viewState, interactionState, oldViewState);
+```
+
+Arguments: 
+
+- `viewState` {Object} The next viewport properties, including: `width`, `height`, `latitude`, `longitude`, `zoom`, `bearing`, `pitch`, `altitude`, `maxZoom`, `minZoom`, `maxPitch`, `minPitch`, `transitionDuration`, `transitionEasing`, `transitionInterpolator`, `transitionInterruption`.
+- `interactionState` {Object} The current interaction that caused this viewport change. See `onInteractionStateChange` for possible fields.
+- `oldViewState` {Object} The current viewport properties.
+
+
+##### `onViewStateChange` {Function}
+
+A newer version of the `onViewportChange` callback. Both are supported and provide equivalent functionality.
+
+```js
+onViewStateChange({viewState, interactionState, oldViewState});
+```
+
+
+##### `onInteractionStateChange` {Function}
+
+Callback that is fired when the user interacted with the map.
+
+```js
+onInteractionStateChange(interactionState)
+```
+
+Possible fields include:
+
+- `interactionState.inTransition` (Boolean)
+- `interactionState.isDragging` (Boolean)
+- `interactionState.isPanning` (Boolean)
+- `interactionState.isRotating` (Boolean)
+- `interactionState.isZooming` (Boolean)
+
+Note:
+* `onInteractionStateChange` may be fired without `onViewportChange`. For example, when the pointer is released at the end of a drag-pan, `isDragging` are reset to `false`, without the viewport's `longitude` and `latitude` changing.
+
+
+##### `onHover` {Function}
+
+Called when the map is hovered over with mouse (not pressed). Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onClick` {Function}
+
+Called when the map is clicked. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onDblClick` {Function}
+
+Called when the map is double clicked. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onMouseDown` {Function}
+
+Called when a pointing device (usually a mouse) is pressed within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onMouseMove` {Function}
+
+Called when a pointing device (usually a mouse) is moved within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onMouseUp` {Function}
+
+Called when a pointing device (usually a mouse) is released within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onTouchStart` {Function}
+
+Called when a `touchstart` event occurs within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onTouchMove` {Function}
+
+Called when a `touchmove` event occurs within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onTouchEnd` {Function}
+
+Called when a `touchend` event occurs within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onMouseEnter` {Function}
+
+Called when a pointing device (usually a mouse) enters a visible portion of one of the interactive layers, defined by the `interactiveLayerIds` prop. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onMouseLeave` {Function}
+
+Called when a pointing device (usually a mouse) leaves a visible portion of one of the interactive layers, defined by the `interactiveLayerIds` prop. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onWheel` {Function}
+
+Called when a `wheel` event occurs within the map. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onMouseOut` {Function}
+
+Called when a point device (usually a mouse) leaves the map's canvas. Receives a [PointerEvent](/docs/components/pointer-event.md) object.
+
+##### `onContextMenu` {Function}
+
+Called when the context menu is activated. Prevent default here to enable right button interaction.
+
+Default: `event => event.preventDefault()`
 
 ##### `onTransitionStart` {Function}
 
@@ -236,7 +318,11 @@ Callback that is fired when a transition is complete.
 
 ## Methods
 
-Same methods as [StaticMap](/docs/components/static-map.md).
+Inherit the following methods from [StaticMap](/docs/components/static-map.md):
+
+- `getMap()`
+- `queryRenderedFeatures(geometry, parameters)`
+
 
 ## Source
 [interactive-map.js](https://github.com/uber/react-map-gl/tree/3.2-release/src/components/interactive-map.js)

--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -66,7 +66,7 @@ Inherit the following props from [StaticMap](/docs/components/static-map.md):
 
 - `style` {Object}
 - `visible` {Bool}
-- `visibilityConstraints`
+- `visibilityConstraints` {Object}
 
 ##### `getCursor` {Function}
 

--- a/docs/components/pointer-event.md
+++ b/docs/components/pointer-event.md
@@ -1,0 +1,25 @@
+# PointerEvent
+
+Event object passed to some of [InteractiveMap](/docs/components/interactive-map.md)'s callback props.
+
+## Members
+
+##### `type` {String}
+
+The name of the event.
+
+##### `point` {Array}
+
+The screen coordinates that is being clicked.
+
+##### `lngLat` {Array}
+
+The geo coordinates that is being clicked.
+
+##### `target` {Element}
+
+The target element of the pointer event.
+
+##### `srcEvent` {Object}
+
+The original browser event.

--- a/docs/components/static-map.md
+++ b/docs/components/static-map.md
@@ -24,20 +24,66 @@ class Map extends Component {
 
 ## Properties
 
+### Initialization
+
+The following props are used during the creation of the Mapbox map.
+
+##### `attributionControl` {Bool} - default: `true`
+
+Equivalent to Mapbox's `attributionControl` [option](https://www.mapbox.com/mapbox-gl-js/api/#map). If `true`, shows Mapbox's attribution control.
+
+##### `disableTokenWarning` {Bool} - default `false`
+
+If the provided API access token is rejected by Mapbox, `StaticMap` renders a warning instead of failing silently. If you know what you are doing and want to hide this warning anyways, set this prop to `true`.
+
+##### `gl` {WebGLContext} ==EXPERIMENTAL==
+
+Use an existing WebGLContext instead of creating a new one. This allows multiple libraries to render into a shared buffer. Use with caution.
+
 ##### `mapboxApiAccessToken` {String}
 
 Mapbox API access token for `MapboxGL`. Required when using Mapbox vector tiles/styles
 Mapbox WebGL context creation option. Useful when you want to export the canvas as a PNG
+
+##### `mapOptions` {Object} - default: `{}`
+
+> Non-public API, see https://github.com/uber/react-map-gl/issues/545
+
+An object of additional options to be passed to Mapbox's [`Map` constructor](https://www.mapbox.com/mapbox-gl-js/api/#map). Options specified here
+will take precedence over those same options if set via props.
+
+##### `preserveDrawingBuffer` {Bool} - default: `false`
+
+Equivalent to Mapbox's `preserveDrawingBuffer` [option](https://www.mapbox.com/mapbox-gl-js/api/#map). If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`.
+
+##### `preventStyleDiffing` {Bool} - default: `false`
+
+If `mapStyle` is assigned an Immutable object, when the prop changes, `StaticMap` can diff between the two values and call the appropriate Mapbox API such as `addLayer`, `removeLayer`, `setStyle`, `setData`, etc.
+This allows apps to update data sources and layer styles efficiently. In use cases such as animation or dynamic showing/hiding layers, style diffing prevents the map from reloading and flickering when the map style changes.
+
+There are known issues with style diffing. As stopgap, use this option to prevent style diffing.
+
+##### `reuseMaps` {Bool} - default: `false`
+
+> This prop is experimental.
+
+If `true`, when the map component is unmounted, instead of calling `remove` on the Mapbox map instance, save it for later reuse. This will avoid repeatedly creating new Mapbox map instances if possible.
+
+Applications that frequently mount and unmount maps may try this prop to help work around a mapbox-gl resource leak issue that can lead to a browser crash in certain situations.
+
+##### `transformRequest` {Function} - default: `null`
+
+A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
+Expected to return an object with a `url` property and optionally `headers` and `credentials` properties.  Equivalent to Mapbox's `transformRequest` [map option](https://www.mapbox.com/mapbox-gl-js/api#map).
+
+
+### Map State
 
 ##### `mapStyle` {String | Object | Immutable.Map}
 
 The Mapbox style. A string url or a
 [MapboxGL style](https://www.mapbox.com/mapbox-gl-style-spec/#layer-interactive)
 object (regular JS object or Immutable.Map).
-
-##### `style` {Object}
-
-The CSS style of the container.
 
 ##### `width` {Number | String} (required)
 
@@ -46,18 +92,6 @@ The width of the map. Can be either a number in pixels, or a valid CSS string.
 ##### `height` {Number | String} (required)
 
 The height of the map. Can be either a number in pixels, or a valid CSS string.
-
-##### `viewState` {Object}
-
-An object containing the view state of the map specified by the following fields:
-* `latitude` {Number} - The latitude of the center of the map.
-* `longitude` {Number} - The longitude of the center of the map.
-* `zoom` {Number} - The tile zoom level of the map. Bounded implicitly by default `minZoom` and `maxZoom` of `MapboxGL`.
-* `bearing` {Number} - default: `0` - The bearing of the viewport.
-* `pitch` {Number} - default: `0` - The pitch of the viewport.
-* `altitude` {Number} - default: `1.5 screen heights`
-
-Note: Either the `viewState`, or the `latitude`, `longitude` and `zoom` properties need to be specified.
 
 ##### `latitude` {Number}
 
@@ -75,7 +109,7 @@ Bounded implicitly by default `minZoom` and `maxZoom` of `MapboxGL`
 
 ##### `bearing` {Number} - default: `0`
 
-Specify the bearing of the viewport, as a top level prop. Only used if `viewState` is not supplied..
+Specify the bearing of the viewport, as a top level prop. Only used if `viewState` is not supplied.
 
 ##### `pitch` {Number} - default: `0`
 
@@ -87,48 +121,28 @@ Specify the pitch of the viewport, as a top level prop. Only used if `viewState`
 
 Altitude of the viewport camera.
 
+##### `viewState` {Object}
+
+An object containing the view state of the map specified by the following fields:
+* `latitude` {Number} - The latitude of the center of the map.
+* `longitude` {Number} - The longitude of the center of the map.
+* `zoom` {Number} - The tile zoom level of the map. Bounded implicitly by default `minZoom` and `maxZoom` of `MapboxGL`.
+* `bearing` {Number} - default: `0` - The bearing of the viewport.
+* `pitch` {Number} - default: `0` - The pitch of the viewport.
+* `altitude` {Number} - default: `1.5 screen heights`
+
+Note: Either the `viewState`, or the `latitude`, `longitude` and `zoom` properties need to be specified.
+
+
+### Render Options
+
+##### `style` {Object}
+
+The CSS style of the map container.
+
 ##### `visible` {Bool} - default: `true`
 
 Whether the map is visible. Unmounting and re-mounting a Mapbox instance is known to be costly. This option offers a way to hide a map using CSS style.
-
-##### `preserveDrawingBuffer` {Bool} - default: `false`
-
-Equivalent to Mapbox's `preserveDrawingBuffer` [option](https://www.mapbox.com/mapbox-gl-js/api/#map). If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`.
-
-##### `attributionControl` {Bool} - default: `true`
-
-Equivalent to Mapbox's `attributionControl` [option](https://www.mapbox.com/mapbox-gl-js/api/#map). If `true`, shows Mapbox's attribution control.
-
-##### `preventStyleDiffing` {Bool} - default: `false`
-
-If `mapStyle` is assigned an Immutable object, when the prop changes, `StaticMap` can diff between the two values and call the appropriate Mapbox API such as `addLayer`, `removeLayer`, `setStyle`, `setData`, etc.
-This allows apps to update data sources and layer styles efficiently. In use cases such as animation or dynamic showing/hiding layers, style diffing prevents the map from reloading and flickering when the map style changes.
-
-There are known issues with style diffing. As stopgap, use this option to prevent style diffing.
-
-##### `disableTokenWarning` {Bool} - default `false`
-
-If the provided API access token is rejected by Mapbox, `StaticMap` renders a warning instead of failing silently. If you know what you are doing and want to hide this warning anyways, set this prop to `true`.
-
-##### `reuseMaps` {Bool} - default: `false`
-
-> This prop is experimental.
-
-If `true`, when the map component is unmounted, instead of calling `remove` on the Mapbox map instance, save it for later reuse. This will avoid repeatedly creating new Mapbox map instances if possible.
-
-Applications that frequently mount and unmount maps may try this prop to help work around a mapbox-gl resource leak issue that can lead to a browser crash in certain situations.
-
-##### `transformRequest` {Function} - default: `null`
-
-A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
-Expected to return an object with a `url` property and optionally `headers` and `credentials` properties.  Equivalent to Mapbox's `transformRequest` [map option](https://www.mapbox.com/mapbox-gl-js/api#map).
-
-##### `mapOptions` {Object} - default: `{}`
-
-> Non-public API, see https://github.com/uber/react-map-gl/issues/545
-
-An object of additional options to be passed to Mapbox's [`Map` constructor](https://www.mapbox.com/mapbox-gl-js/api/#map). Options specified here
-will take precedence over those same options if set via props.
 
 ##### `visibilityConstraints` {Object} ==EXPERIMENTAL==
 
@@ -136,12 +150,8 @@ An object that specifies bounds for viewport props with `min*`, `max*` keys. If 
 
 Default: `{ minZoom: 0, maxZoom: 20, minPitch: 0, maxPitch: 60 }`
 
-##### `gl` {WebGLContext} ==EXPERIMENTAL==
 
-Use an existing WebGLContext instead of creating a new one. This allows multiple libraries to render into a shared buffer. Use with caution.
-
-
-## Callbacks
+### Callbacks
 
 ##### `onLoad` {Function} - default: `no-op function`
 

--- a/website/src/constants/pages.js
+++ b/website/src/constants/pages.js
@@ -130,15 +130,19 @@ const docPages = {
           content: getDocUrl('components/map-controls.md')
         },
         {
-          name: 'Navigation Control',
+          name: 'NavigationControl',
           content: getDocUrl('components/navigation-control.md')
+        },
+        {
+          name: 'PointerEvent',
+          content: getDocUrl('components/pointer-event.md')
         },
         {
           name: 'Popup',
           content: getDocUrl('components/popup.md')
         },
         {
-          name: 'Static Map',
+          name: 'StaticMap',
           content: getDocUrl('components/static-map.md')
         },
         {


### PR DESCRIPTION
| Mapbox events | InteractiveMap props |
| ----- | ----- |
| `mousedown` | `onMouseDown` |
| `mouseup` | `onMouseUp` |
| `mousemove` | `onMouseMove` |
| `touchstart` | `onTouchStart` |
| `touchmove` | `onTouchMove` |
| `touchend` | `onTouchEnd` |
| `mouseenter` | `onMouseEnter` (applies to `interactiveLayerIds`) |
| `mouseleave` | `onMouseLeave` (applies to `interactiveLayerIds`) |
| `click` | `onClick` |
| `dblclick` | `onDblClick` |
| `mouseout` | `onMouseOut` |
| `contextmenu` | `onContextMenu` |
| `wheel` | `onWheel` |