### PR TITLE
Remove click delay in map controls when `captureDoubleClick` is on

### DIFF
--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -112,9 +112,9 @@ export default class BaseControl extends PureComponent {
   _onPointerUp = (evt) => {
     if (this.props.captureDoubleClick) {
       const {eventManager} = this._context;
-      const doubletap = eventManager.manager.get('doubletap');
+      const {options: {enable}} = eventManager.manager.get('doubletap');
       // Temporarily disable doubletap
-      if (doubletap.options.enable) {
+      if (enable) {
         eventManager._toggleRecognizer('doubletap', false);
         /* global setTimeout */
         setTimeout(() => {

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -88,7 +88,7 @@ export default class BaseControl extends PureComponent {
         wheel: this._onScroll,
         panstart: this._onDragStart,
         click: this._onClick,
-        dblclick: this._onDoubleClick
+        pointerup: this._onPointerUp
       };
 
       eventManager.on(events, ref);
@@ -109,14 +109,23 @@ export default class BaseControl extends PureComponent {
     }
   }
 
-  _onClick = (evt) => {
-    if (this.props.captureClick) {
-      evt.stopPropagation();
+  _onPointerUp = (evt) => {
+    if (this.props.captureDoubleClick) {
+      const {eventManager} = this._context;
+      const doubletap = eventManager.manager.get('doubletap');
+      // Temporarily disable doubletap
+      if (doubletap.options.enable) {
+        eventManager._toggleRecognizer('doubletap', false);
+        /* global setTimeout */
+        setTimeout(() => {
+          eventManager._toggleRecognizer('doubletap', true);
+        }, 0);
+      }
     }
   }
 
-  _onDoubleClick = (evt) => {
-    if (this.props.captureDoubleClick) {
+  _onClick = (evt) => {
+    if (this.props.captureClick) {
       evt.stopPropagation();
     }
   }


### PR DESCRIPTION
Reported in https://github.com/uber/react-map-gl/issues/569

Avoid registering the `dblclick` event as it adds a 300ms delay before firing `click`.