### PR TITLE
Fix render error when using `viewState` instead of flat props

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -216,7 +216,7 @@ export default class StaticMap extends PureComponent {
     this._updateMapSize(width, height);
 
     const staticContext = {
-      viewport: new WebMercatorViewport(Object.assign({}, this.props, {
+      viewport: new WebMercatorViewport(Object.assign({}, this.props, this.props.viewState, {
         width,
         height
       })),

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,9 @@ export {
 
 // Experimental Features (May change in minor version bumps, use at your own risk)
 import MapControls from './utils/map-controls';
+import {StaticContext} from './components/static-map';
 
 export const experimental = {
-  MapControls
+  MapControls,
+  MapContext: StaticContext
 };


### PR DESCRIPTION
#### Change List
- Handle `viewState` prop when creating the viewport
- Add `StaticContext` to experimental export (for ability to use control components without base map)