### PR TITLE
Add support for Create React App access token environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To show maps from a service such as Mapbox you will need to register on their we
 There are several ways to provide a token to your app, as showcased in some of the example folders:
 
 * Provide a `mapboxApiAccessToken` prop to the map component
-* Set the `MapboxAccessToken` environment variable
+* Set the `MapboxAccessToken` environment variable (or set `REACT_APP_MAPBOX_ACCESS_TOKEN` if you are using Create React App)
 * Provide it in the URL, e.g `?access_token=TOKEN`
 
 But we would recommend using something like [dotenv](https://github.com/motdotla/dotenv) and put your key in an untracked `.env` file, that will then expose it as a `process.env` variable, with much less leaking risks.

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -91,8 +91,8 @@ export function getAccessToken() {
   }
 
   if (!accessToken && typeof process !== 'undefined') {
-    // Note: This depends on bundler plugins (e.g. webpack) inmporting environment correctly
-    accessToken = accessToken || process.env.MapboxAccessToken; // eslint-disable-line
+    // Note: This depends on bundler plugins (e.g. webpack) importing environment correctly
+    accessToken = accessToken || process.env.MapboxAccessToken || process.env.REACT_APP_MAPBOX_ACCESS_TOKEN; // eslint-disable-line
   }
 
   return accessToken || null;


### PR DESCRIPTION
This change adds support for setting access token environment variable
for applications built with Create React App.

Addresses #425.