### PR TITLE
API audit

### DIFF
--- a/docs/advanced/custom-map-controller.md
+++ b/docs/advanced/custom-map-controller.md
@@ -1,36 +1,37 @@
-# Custom Map Controls
+# Custom Map Controller
 
 ## Overriding The Default Map Controller
 
-To change the default behavior of map interaction, you can provide a custom map control to the `mapControls` prop of `InteractiveMap`.
+To change the default behavior of map interaction, you can provide a custom map control to the `mapController` prop of `InteractiveMap`.
 
 This custom map control must offer the following interface:
 - `setOptions(options)` - called by `InteractiveMap` when props change.
 
 ```jsx
-  const mapControls = new MyMapControls();
+  const mapController = new MyMapController();
 
   render() {
-    return <ReactMapGL mapControls={mapControls} ... />;
+    return <ReactMapGL mapController={mapController} ... />;
   }
 ```
 
 
-Documentation of [the MapControls class](/docs/components/map-controls.md).
+Documentation of [the MapController class](/docs/components/map-controller.md).
 
 
 ## Examples
 
 A simple example to swap drag pan and drag rotate:
-```js
-  /// my-map-controls.js
-  import {experimental} from 'react-map-gl';
 
-  export default class MyMapControls extends experimental.MapControls {
+```js
+  /// my-map-controller.js
+  import {MapController} from 'react-map-gl';
+
+  export default class MyMapController extends MapController {
 
     _onPan(event) {
       return this.isFunctionKeyPressed(event) || event.rightButton ?
-    //  Default implementation in MapControls
+    //  Default implementation in MapController
     //  this._onPanRotate(event) : this._onPanMove(event);
         this._onPanMove(event) : this._onPanRotate(event);
     }
@@ -38,11 +39,12 @@ A simple example to swap drag pan and drag rotate:
 ```
 
 Overwrite existing event handling:
-```js
-  /// my-map-controls.js
-  import {experimental} from 'react-map-gl';
 
-  export default class MyMapControls extends experimental.MapControls {
+```js
+  /// my-map-controller.js
+  import {MapController} from 'react-map-gl';
+
+  export default class MyMapController extends MapController {
 
     // Override the default double tap handler
     _onDoubleTap(event) {
@@ -57,11 +59,12 @@ Overwrite existing event handling:
 ```
 
 Listen to additional events:
-```js
-  /// my-map-controls.js
-  import {experimental} from 'react-map-gl';
 
-  export default class MyMapControls extends experimental.MapControls {
+```js
+  /// my-map-controller.js
+  import {MapController} from 'react-map-gl';
+
+  export default class MyMapController extends MapController {
 
     constructor() {
       super();
@@ -69,7 +72,7 @@ Listen to additional events:
       this.events = ['click'];
     }
 
-    // Override the default handler in MapControls
+    // Override the default handler in MapController
     handleEvent(event) {
       if (event.type === 'click') {
         console.log('hi');
@@ -80,11 +83,12 @@ Listen to additional events:
 ```
 
 Add a custom callback:
-```js
-  /// my-map-controls.js
-  import {experimental} from 'react-map-gl';
 
-  export default class MyMapControls extends experimental.MapControls {
+```js
+  /// my-map-controller.js
+  import {MapController} from 'react-map-gl';
+
+  export default class MyMapController extends MapController {
 
     setOptions(options) {
       super.setOptions(options);

--- a/docs/components/interactive-map.md
+++ b/docs/components/interactive-map.md
@@ -133,9 +133,9 @@ By default, the map captures all touch interactions. This prop is useful for mob
 
 Radius to detect features around a clicked point.
 
-##### `mapControls` {Object}
+##### `controller` {Object}
 
-A map control instance to replace the default map controls.
+A map controller instance to replace the default map controller.
 
 This object must implement the following interface:
 - `events` - An array of subscribed events

--- a/docs/components/map-controller.md
+++ b/docs/components/map-controller.md
@@ -1,6 +1,6 @@
-# MapControls (experimental)
+# MapController
 
-The easiest way to create a custom map control is to extend the default `MapControls` class.
+The easiest way to create a custom map control is to extend the default `MapController` class.
 
 ## Properties
 
@@ -8,7 +8,7 @@ The easiest way to create a custom map control is to extend the default `MapCont
 
 A list of additional event names that this control subscribes to.
 
-Available events: `click`, `dblclick`, `tap`, `doubletap`, `press`, `pinch`, `pinchin`, `pinchout`, `pinchstart`, `pinchmove`, `pinchend`, `pinchcancel`, `rotate`, `rotatestart`, `rotatemove`, `rotateend`, `rotatecancel`, `pan`, `panstart`, `panmove`, `panup`, `pandown`, `panleft`, `panright`, `panend`, `pancancel`, `swipe`, `swipeleft`, `swiperight`, `swipeup`, `swipedown`, `pointerdown`, `pointermove`, `pointerup`, `touchstart`, `touchmove`, `touchend`, `mousedown`, `mousemove`, `mouseup`, `keydown`, and `keyup`.
+Available events: `click`, `dblclick`, `tap`, `doubletap`, `press`, `pinch`, `pinchin`, `pinchout`, `pinchstart`, `pinchmove`, `pinchend`, `pinchcancel`, `rotate`, `rotatestart`, `rotatemove`, `rotateend`, `rotatecancel`, `pan`, `panstart`, `panmove`, `panup`, `pandown`, `panleft`, `panright`, `panend`, `pancancel`, `swipe`, `swipeleft`, `swiperight`, `swipeup`, `swipedown`, `pointerdown`, `pointermove`, `pointerup`, `keydown`, and `keyup`.
 
 The following events are toggled on/off by InteractiveMap props: 
 
@@ -69,4 +69,4 @@ Invoke `onViewportChange` callback with a new map state.
 
 
 ## Source
-[map-controls.js](https://github.com/uber/react-map-gl/tree/3.2-release/src/utils/map-controls.js)
+[map-controller.js](https://github.com/uber/react-map-gl/tree/3.2-release/src/utils/map-controller.js)

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -8,7 +8,7 @@ import WebMercatorViewport from 'viewport-mercator-project';
 import TransitionManager from '../utils/transition-manager';
 
 import {EventManager} from 'mjolnir.js';
-import MapControls from '../utils/map-controls';
+import MapController from '../utils/map-controller';
 import config from '../config';
 import deprecateWarn from '../utils/deprecate-warn';
 
@@ -94,10 +94,10 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
   /** Accessor that returns a cursor style to show interactive state */
   getCursor: PropTypes.func,
 
-  // A map control instance to replace the default map controls
+  // A map control instance to replace the default map controller
   // The object must expose one property: `events` as an array of subscribed
   // event names; and two methods: `setState(state)` and `handle(event)`
-  mapControls: PropTypes.shape({
+  controller: PropTypes.shape({
     events: PropTypes.arrayOf(PropTypes.string),
     handleEvent: PropTypes.func
   })
@@ -145,9 +145,9 @@ export default class InteractiveMap extends PureComponent {
       isHovering: false
     };
 
-    // If props.mapControls is not provided, fallback to default MapControls instance
+    // If props.controller is not provided, fallback to default MapController instance
     // Cannot use defaultProps here because it needs to be per map instance
-    this._mapControls = props.mapControls || new MapControls();
+    this._controller = props.controller || new MapController();
 
     this._eventManager = new EventManager(null, {
       legacyBlockScroll: false,
@@ -201,7 +201,7 @@ export default class InteractiveMap extends PureComponent {
       height: this._height
     });
 
-    this._mapControls.setOptions(props);
+    this._controller.setOptions(props);
   }
 
   _getFeatures({pos, radius}) {
@@ -368,7 +368,7 @@ export default class InteractiveMap extends PureComponent {
 
     return createElement(InteractiveContext.Provider, {value: interactiveContext},
       createElement('div', {
-        key: 'map-controls',
+        key: 'event-canvas',
         ref: this._eventCanvasRef,
         style: eventCanvasStyle
       },

--- a/src/index.js
+++ b/src/index.js
@@ -34,20 +34,14 @@ export {default as CanvasOverlay} from './overlays/canvas-overlay';
 export {default as HTMLOverlay} from './overlays/html-overlay';
 export {default as SVGOverlay} from './overlays/svg-overlay';
 
+// Utilities
 export {TRANSITION_EVENTS} from './utils/transition-manager';
 export {
   TransitionInterpolator,
   LinearInterpolator,
   ViewportFlyToInterpolator as FlyToInterpolator
 } from './utils/transition';
-
-// Utilities
+export {MapControls} from './utils/map-controls';
 
 // Experimental Features (May change in minor version bumps, use at your own risk)
-import MapControls from './utils/map-controls';
-import {StaticContext} from './components/static-map';
-
-export const experimental = {
-  MapControls,
-  MapContext: StaticContext
-};
+export {StaticContext as _StaticContext} from './components/static-map';

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export {
   LinearInterpolator,
   ViewportFlyToInterpolator as FlyToInterpolator
 } from './utils/transition';
-export {MapControls} from './utils/map-controls';
+export {default as MapController} from './utils/map-controller';
 
 // Experimental Features (May change in minor version bumps, use at your own risk)
 export {StaticContext as _StaticContext} from './components/static-map';

--- a/src/utils/deprecate-warn.js
+++ b/src/utils/deprecate-warn.js
@@ -4,11 +4,12 @@ const DEPRECATED_PROPS = [
   {old: 'perspectiveEnabled', new: 'dragRotate'},
   {old: 'onHoverFeatures', new: 'onHover'},
   {old: 'onClickFeatures', new: 'onClick'},
-  {old: 'touchZoomRotate', new: 'touchZoom, touchRotate'}
+  {old: 'touchZoomRotate', new: 'touchZoom, touchRotate'},
+  {old: 'mapControls', new: 'controller'}
 ];
 
 function getDeprecatedText(name) {
-  return `react-map-gl: \`${name}\` is deprecated and will be removed in a later version.`;
+  return `react-map-gl: \`${name}\` is removed.`;
 }
 
 function getNewText(name) {

--- a/src/utils/map-controller.js
+++ b/src/utils/map-controller.js
@@ -137,9 +137,6 @@ export default class MapController {
    */
   setOptions(options) {
     const {
-      // TODO(deprecate): remove this when `touchZoomRotate` gets deprecated
-      touchZoomRotate = true,
-
       onViewportChange,
       onStateChange,
       eventManager = this.eventManager,
@@ -178,7 +175,7 @@ export default class MapController {
     // Register/unregister events
     this.toggleEvents(EVENT_TYPES.WHEEL, isInteractive && scrollZoom);
     this.toggleEvents(EVENT_TYPES.PAN, isInteractive && (dragPan || dragRotate));
-    this.toggleEvents(EVENT_TYPES.PINCH, isInteractive && touchZoomRotate);
+    this.toggleEvents(EVENT_TYPES.PINCH, isInteractive && (touchZoom || touchRotate));
     this.toggleEvents(EVENT_TYPES.DOUBLE_TAP, isInteractive && doubleClickZoom);
     this.toggleEvents(EVENT_TYPES.KEYBOARD, isInteractive && keyboard);
 
@@ -187,8 +184,8 @@ export default class MapController {
     this.dragPan = dragPan;
     this.dragRotate = dragRotate;
     this.doubleClickZoom = doubleClickZoom;
-    this.touchZoom = touchZoomRotate && touchZoom;
-    this.touchRotate = touchZoomRotate && touchRotate;
+    this.touchZoom = touchZoom;
+    this.touchRotate = touchRotate;
     this.keyboard = keyboard;
   }
 

--- a/src/utils/map-controller.js
+++ b/src/utils/map-controller.js
@@ -45,7 +45,7 @@ const EVENT_TYPES = {
   KEYBOARD: ['keydown']
 };
 
-export default class MapControls {
+export default class MapController {
   /**
    * @classdesc
    * A class that handles events and updates mercator style viewport parameters

--- a/website/src/constants/pages.js
+++ b/website/src/constants/pages.js
@@ -84,8 +84,8 @@ const docPages = {
           content: getDocUrl('overlays/custom-components.md')
         },
         {
-          name: 'Custom Map Controls',
-          content: getDocUrl('advanced/custom-map-controls.md')
+          name: 'Custom Map Controller',
+          content: getDocUrl('advanced/custom-map-controller.md')
         },
         {
           name: 'Custom Overlays',
@@ -126,8 +126,8 @@ const docPages = {
           content: getDocUrl('components/marker.md')
         },
         {
-          name: 'MapControls',
-          content: getDocUrl('components/map-controls.md')
+          name: 'MapController',
+          content: getDocUrl('components/map-controller.md')
         },
         {
           name: 'NavigationControl',


### PR DESCRIPTION
- Rename `MapControls` to `MapController`, move to official export
- Rename `InteractiveMap`'s `mapControls` prop to `controller`
- Use underscore convention instead of `experimental` object to enable tree-shaking