### PR TITLE
Various bug fixes

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -186,7 +186,7 @@ export default class InteractiveMap extends PureComponent {
     return this._staticMapRef.current ? this._staticMapRef.current.getMap() : null;
   }
 
-  queryRenderedFeatures = (geometry, options) => {
+  queryRenderedFeatures = (geometry, options = {}) => {
     return this.getMap().queryRenderedFeatures(geometry, options);
   }
 

--- a/src/utils/map-controller.js
+++ b/src/utils/map-controller.js
@@ -154,7 +154,7 @@ export default class MapController {
     this.onViewportChange = onViewportChange;
     this.onStateChange = onStateChange;
 
-    if (this.mapStateProps && this.mapStateProps.height !== options.height) {
+    if (!this.mapStateProps || this.mapStateProps.height !== options.height) {
       // Dimensions changed, normalize the props
       this.updateViewport(new MapState(options));
     }

--- a/src/utils/transition/linear-interpolator.js
+++ b/src/utils/transition/linear-interpolator.js
@@ -34,9 +34,14 @@ export default class LinearInterpolator extends TransitionInterpolator {
     const endViewportProps = {};
 
     if (this.around) {
+      // anchor point in origin screen coordinates
+      startViewportProps.around = this.around;
+      // anchor point in spherical coordinates
+      const aroundLngLat = new WebMercatorViewport(startProps).unproject(this.around);
       Object.assign(endViewportProps, endProps, {
-        around: this.around,
-        aroundLngLat: new WebMercatorViewport(endProps).unproject(this.around)
+        // anchor point in destination screen coordinates
+        around: new WebMercatorViewport(endProps).project(aroundLngLat),
+        aroundLngLat
       });
     }
 
@@ -66,7 +71,8 @@ export default class LinearInterpolator extends TransitionInterpolator {
       const [longitude, latitude] = new WebMercatorViewport(Object.assign({}, endProps, viewport))
         .getMapCenterByLngLatPosition({
           lngLat: endProps.aroundLngLat,
-          pos: endProps.around
+          // anchor point in current screen coordinates
+          pos: lerp(startProps.around, endProps.around, t)
         });
       viewport.longitude = longitude;
       viewport.latitude = latitude;


### PR DESCRIPTION
- Add parameter fallback to `InteractiveMap.getRenderedFeatures` (mapbox throws error if `undefined` is passed as the second argument)
- If using relative dimensions, `onViewportChange` should be called on initial render to update width and height
- `LinearTransitionInterpolator` deals with `around` translation between start and end viewports