### PR TITLE
export InteractiveContext at the top level

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,3 +45,4 @@ export {default as MapController} from './utils/map-controller';
 
 // Experimental Features (May change in minor version bumps, use at your own risk)
 export {StaticContext as _MapContext} from './components/static-map';
+export {InteractiveContext as _InteractiveMapContext} from './components/interactive-map';


### PR DESCRIPTION
I just tried react-map-gl v4 - thanks for all the great work!

One thing that would be helpful: it is useful to get access to the `eventManager` on `context` like we were able to prior to react-map-gl v4. Exporting this at the top level is super helpful so we don't have to import from deep in the directory structure.

If you'd prefer a different name for the export let me know.