### PR TITLE
Fix popup bug when closeOnClick is off

### DIFF
--- a/examples/controls/src/app.js
+++ b/examples/controls/src/app.js
@@ -57,6 +57,7 @@ export default class App extends Component {
         anchor="top"
         longitude={popupInfo.longitude}
         latitude={popupInfo.latitude}
+        closeOnClick={false}
         onClose={() => this.setState({popupInfo: null})} >
         <CityInfo info={popupInfo} />
       </Popup>

--- a/examples/controls/src/city-pin.js
+++ b/examples/controls/src/city-pin.js
@@ -5,6 +5,7 @@ const ICON = `M20.2,15.7L20.2,15.7c1.1-1.6,1.8-3.6,1.8-5.7c0-5.6-4.5-10-10-10S2,
   C20.1,15.8,20.2,15.8,20.2,15.7z`;
 
 const pinStyle = {
+  cursor: 'pointer',
   fill: '#d00',
   stroke: 'none'
 };

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -136,27 +136,14 @@ export default class Popup extends BaseControl {
     return style;
   }
 
-  /*
-   * Hack -
-   * React's `onClick` is called before mjolnir.js' `click` event (aka `tap` from hammer.js)
-   * which has a configurable delay.
-   * If we close the popup on the React event, by the time `click` fires, this component will
-   * have been unmounted, thus `captureClick` will not work.
-   * Instead, we flag the popup as closed on the React event, and actually close it on the hammer.js
-   * event.
-   */
   _onClick = (evt) => {
     if (this.props.captureClick) {
       evt.stopPropagation();
     }
 
-    if (this.props.closeOnClick || this._closeOnClick) {
+    if (this.props.closeOnClick || evt.target.className === 'mapboxgl-popup-close-button') {
       this.props.onClose();
     }
-  }
-
-  _onClose = () => {
-    this._closeOnClick = true;
   }
 
   _renderTip(positionType) {
@@ -171,16 +158,19 @@ export default class Popup extends BaseControl {
 
   _renderContent() {
     const {closeButton, children} = this.props;
+    // If eventManager does not exist (using with static map), listen to React event
+    const onClick = this._context.eventManager ? null : this._onClick;
+
     return createElement('div', {
       key: 'content',
       ref: this._contentRef,
-      className: 'mapboxgl-popup-content'
+      className: 'mapboxgl-popup-content',
+      onClick
     }, [
       closeButton && createElement('button', {
         key: 'close-button',
         className: 'mapboxgl-popup-close-button',
-        type: 'button',
-        onClick: this._onClose
+        type: 'button'
       }, '×'),
       children
     ]);


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/657

This bug was triggered by a recent fix that removed the click delay if `captureDoubleClick` is on. The old implementation assumed that eventManager's `click` event is always fired after React, which is no longer the case.