### PR TITLE
Fix minor issues in viewport transition docs code

### DIFF
--- a/docs/advanced/viewport-transition.md
+++ b/docs/advanced/viewport-transition.md
@@ -12,8 +12,8 @@ class MyApp extends React.Component {
     state = {
         viewport: {
             width: 800,
-            heigh: 600,
-            longitude: -122.45
+            height: 600,
+            longitude: -122.45,
             latitude: 37.78,
             zoom: 14
         }


### PR DESCRIPTION
Was missing a "t" for "height", and a comma after the longitude