### PR TITLE
Fix dragging marker with offset

### DIFF
--- a/examples/draggable-markers/src/app.js
+++ b/examples/draggable-markers/src/app.js
@@ -81,6 +81,8 @@ export default class App extends Component {
         <Marker 
           longitude={marker.longitude}
           latitude={marker.latitude}
+          offsetTop={-20}
+          offsetLeft={-10}
           draggable
           onDragStart={this._onMarkerDragStart}
           onDrag={this._onMarkerDrag}

--- a/examples/draggable-markers/src/control-panel.js
+++ b/examples/draggable-markers/src/control-panel.js
@@ -13,7 +13,7 @@ export default class ControlPanel extends PureComponent {
     const {events = {}} = this.props;
     const lngLat = events[eventName];
     return (
-      <div>
+      <div key={eventName}>
         <strong>{eventName}:</strong>{' '}
         {lngLat ? lngLat.map(round5).join(', ') : <em>null</em>}
       </div>
@@ -26,9 +26,9 @@ export default class ControlPanel extends PureComponent {
       <Container>
         <h3>Draggable Marker</h3>
         <p>Try dragging the marker to another location.</p>
-        <p>
+        <div>
           {eventNames.map(this.renderEvent)}
-        </p>
+        </div>
         {/* TODO add a "View Code" link here when we know the release */}
       </Container>
     );

--- a/examples/draggable-markers/src/pin.js
+++ b/examples/draggable-markers/src/pin.js
@@ -18,7 +18,7 @@ export default class Pin extends PureComponent {
       <svg 
         height={size}
         viewBox="0 0 24 24"
-        style={{...pinStyle, transform: `translate(${-size / 2}px,${-size}px)`}}
+        style={pinStyle}
       >
         <path d={ICON}/>
       </svg>

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -28,16 +28,7 @@ const propTypes = Object.assign({}, DraggableControl.propTypes, {
   // Longitude of the anchor point
   longitude: PropTypes.number.isRequired,
   // Latitude of the anchor point
-  latitude: PropTypes.number.isRequired,
-  // Offset from the left
-  offsetLeft: PropTypes.number,
-  // Offset from the top
-  offsetTop: PropTypes.number,
-  // Drag and Drop props
-  draggable: PropTypes.bool,
-  onDrag: PropTypes.func,
-  onDragEnd: PropTypes.func,
-  onDragStart: PropTypes.func
+  latitude: PropTypes.number.isRequired
 });
 
 const defaultProps = Object.assign({}, DraggableControl.defaultProps, {
@@ -58,18 +49,33 @@ export default class Marker extends DraggableControl {
   static propTypes = propTypes;
   static defaultProps = defaultProps;
 
-  _render() {
-    const {className, longitude, latitude, offsetLeft, offsetTop} = this.props;
+  _getPosition(): [number, number] {
+    const {longitude, latitude, offsetLeft, offsetTop} = this.props;
     const {dragPos, dragOffset} = this.state;
 
-    const [x, y] = dragPos ?
-      this._getDraggedPosition(dragPos, dragOffset) :
-      this._context.viewport.project([longitude, latitude]);
+    // If dragging, just return the current drag position
+    if (dragPos) {
+      return this._getDraggedPosition(dragPos, dragOffset);
+    }
+
+    // Otherwise return the projected lat/lng with offset
+    let [x, y] = this._context.viewport.project([longitude, latitude]);
+    x += offsetLeft;
+    y += offsetTop;
+    return [x, y];
+  }
+
+  _render() {
+    const {className, draggable} = this.props;
+    const {dragPos} = this.state;
+
+    const [x, y] = this._getPosition();
 
     const containerStyle = {
       position: 'absolute',
-      left: x + offsetLeft,
-      top: y + offsetTop
+      left: x,
+      top: y,
+      cursor: draggable ? (dragPos ? 'grabbing' : 'grab') : 'auto'
     };
 
     return createElement('div', {


### PR DESCRIPTION
Fixes #691 

<img src="https://user-images.githubusercontent.com/875591/51363958-21218080-1a8f-11e9-96a9-557ac69ec242.gif" width="350" />

Think I overlooked this initially because the `<Pin>` component used in examples uses custom `translate` rules instead of the Marker offset props. I've updated the example and fixed the root issue.