### PR TITLE
Reverse polarity of compass bearing rotation

### DIFF
--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -75,7 +75,7 @@ export default class NavigationControl extends BaseControl {
     const {bearing} = this._context.viewport;
     return createElement('span', {
       className: 'mapboxgl-ctrl-compass-arrow',
-      style: {transform: `rotate(${bearing}deg)`}
+      style: {transform: `rotate(${-bearing}deg)`}
     });
   }
 


### PR DESCRIPTION
## Overview

Using the map bearing number directly in the CSS transform rule for the navigation control results in the compass pointing in the direction of the rotation, rather than pointing north.

In the core library, some math is applied to the map angle to set the
compass direction (see https://github.com/mapbox/mapbox-gl-js/blob/d39a7db478a0b686199b750548397d87d61e8f3b/src/ui/control/navigation_control.js#L62). This is equivalent to reversing the polarity of the bearing, and using that to set the compass direction, which will now point north.

## Demo

**Existing behavior**

Note that the maps are rotated to roughly the same bearing, but the compasses point in different directions.

*react-map-gl example https://uber.github.io/react-map-gl/#/Examples/markers-popups*

![image](https://user-images.githubusercontent.com/1042475/51405378-31d00600-1b24-11e9-9960-e28a1e23a176.png)

*mapboxgl.js example https://docs.mapbox.com/mapbox-gl-js/example/navigation/*

![image](https://user-images.githubusercontent.com/1042475/51405488-7196ed80-1b24-11e9-8653-02b94f07b5b9.png)

**Fixed behavior**

*react-map-gl example on this branch*

![image](https://user-images.githubusercontent.com/1042475/51405610-cc304980-1b24-11e9-9a4d-0bbdec9effa2.png)

Also, here are some random sampling of the map angle, bearing, and compass rotation value read directly from MapboxGL.js. You can see that the rotation is the same number as the bearing, with the opposite polarity. 

```
Angle:  0
Bearing:  -0
Rotation:  0

Angle:  -0.43284165449459294
Bearing:  24.799999999999955
Rotation:  -24.799999999999955

Angle:  -1.4521139376592809
Bearing:  83.19999999999993
Rotation:  -83.19999999999993
```
