### PR TITLE
Bug fix: implement onLoad event calling when reuseMaps is set to true

### DIFF
--- a/examples/main/constants/toc.js
+++ b/examples/main/constants/toc.js
@@ -77,15 +77,14 @@ export const standaloneExamples = [
     component: ZoomToBounds
   },
   {
-<<<<<<< HEAD
     path: 'reuse-map',
     name: 'ReuseMaps',
     component: ReuseMap
-=======
+  },
+  {
     path: 'heatmap',
     name: 'Heatmap',
     component: Heatmap
->>>>>>> upstream/master
   }
 ];
 

--- a/examples/main/constants/toc.js
+++ b/examples/main/constants/toc.js
@@ -16,6 +16,7 @@ import Interaction from '../../interaction/src/app';
 import Layers from '../../layers/src/app';
 import ViewportAnimation from '../../viewport-animation/src/app';
 import ZoomToBounds from '../../zoom-to-bounds/src/app';
+import ReuseMap from '../../reuse-map/src/app';
 
 export const BASIC_EXAMPLES = 'basicExamples';
 export const STANDALONE_EXAMPLES = 'standalonExamples';
@@ -73,6 +74,11 @@ export const standaloneExamples = [
     path: 'zoom-to-bounds',
     name: 'Zoom To Bounds',
     component: ZoomToBounds
+  },
+  {
+    path: 'reuse-map',
+    name: 'ReuseMaps',
+    component: ReuseMap
   }
 ];
 

--- a/examples/main/constants/toc.js
+++ b/examples/main/constants/toc.js
@@ -16,7 +16,6 @@ import Interaction from '../../interaction/src/app';
 import Layers from '../../layers/src/app';
 import ViewportAnimation from '../../viewport-animation/src/app';
 import ZoomToBounds from '../../zoom-to-bounds/src/app';
-import ReuseMap from '../../reuse-map/src/app';
 import Heatmap from '../../heatmap/src/app';
 
 export const BASIC_EXAMPLES = 'basicExamples';
@@ -75,11 +74,6 @@ export const standaloneExamples = [
     path: 'zoom-to-bounds',
     name: 'Zoom To Bounds',
     component: ZoomToBounds
-  },
-  {
-    path: 'reuse-map',
-    name: 'ReuseMaps',
-    component: ReuseMap
   },
   {
     path: 'heatmap',

--- a/examples/reuse-map/src/bart-map.js
+++ b/examples/reuse-map/src/bart-map.js
@@ -19,6 +19,9 @@ export default class BartMap extends Component {
 
   _onViewportChange = viewState => this.setState({viewState});
 
+  // eslint-disable-next-line no-alert
+  _onMapLoad = (event) => alert('Fire MapGL onLoad event');
+
   _renderMarker(station, i) {
     const {name, coordinates} = station;
     return (
@@ -40,6 +43,7 @@ export default class BartMap extends Component {
         width="100%"
         height="100%"
         onViewportChange={this._onViewportChange}
+        onLoad={this._onMapLoad}
 
         reuseMaps={true}
       >

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -236,17 +236,22 @@ export default class Mapbox {
       this._map._container = newContainer;
       Mapbox.savedMap = null;
 
-      // Update style and call onload again
+      // Step3: update style and call onload again
+      const fireLoadEvent = () => props.onLoad({
+        type: 'load',
+        target: this._map
+      });
+
       if (props.mapStyle) {
-        this._map.setStyle(props.mapStyle);
+        this._map.setStyle(props.mapStyle, {
+          diff: true
+        });
 
         // call onload event handler after style fully loaded when style needs update
-        this._map.once('style.load', props.onLoad);
+        (this._map.isStyleLoaded() ?
+          fireLoadEvent() : this._map.once('styledata', fireLoadEvent))();
       } else {
-        props.onLoad({
-          type: 'load',
-          target: this._map
-        });
+        fireLoadEvent();
       }
     } else {
       if (props.gl) {

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -236,13 +236,18 @@ export default class Mapbox {
       this._map._container = newContainer;
       Mapbox.savedMap = null;
 
-      // Update style
+      // Update style and call onload again
       if (props.mapStyle) {
         this._map.setStyle(props.mapStyle);
-      }
 
-      // TODO - need to call onload again, need to track with Promise?
-      props.onLoad();
+        // call onload event handler after style fully loaded when style needs update
+        this._map.once('style.load', props.onLoad);
+      } else {
+        props.onLoad({
+          type: 'load',
+          target: this._map
+        });
+      }
     } else {
       if (props.gl) {
         const getContext = HTMLCanvasElement.prototype.getContext;

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -218,7 +218,7 @@ export default class Mapbox {
   }
 
   // PRIVATE API
-
+  // eslint-disable-next-line max-statements
   _create(props: Props) {
     // Reuse a saved map, if available
     if (props.reuseMaps && Mapbox.savedMap) {
@@ -248,8 +248,11 @@ export default class Mapbox {
         });
 
         // call onload event handler after style fully loaded when style needs update
-        (this._map.isStyleLoaded() ?
-          fireLoadEvent() : this._map.once('styledata', fireLoadEvent))();
+        if (this._map.isStyleLoaded()) {
+          fireLoadEvent();
+        } else {
+          this._map.once('styledata', fireLoadEvent);
+        }
       } else {
         fireLoadEvent();
       }


### PR DESCRIPTION
## Description and resolution

According to the discussion in #699 , there's a TODO inside mapbox.js, which is calling onLoad event again when map instance is re-created again with its' property `reuseMaps` set to true.

However, we need to handle two situations here:

1. We need to `setStyle` with customized `mapStyle`: In this situation, we need to wait until style is loaded, and then call `onLoad` event handler; we choose `.once` API here to listen `style.load` event;
2. We don't need to `setStyle` with customized `mapStyle`: In this situation, we can directly generate an `event` object and pass it to `props.onLoad` method and call it right now;

## Tests and documentation

* Test: `npm run test` passed with 222 tests.
* Documentation: No need to update document since there's not API change with this commit;
