### PR TITLE
Remove link to redux-map-gl in documentation

### DIFF
--- a/docs/get-started/state-management.md
+++ b/docs/get-started/state-management.md
@@ -52,5 +52,3 @@ render() {
 If you're using redux, it is very easy to hook this component up to store state in the redux state tree.
 The simplest way is to take all properties passed to the `onViewportChange` function property and add them
 directly into the store. This state can then be passed back to the `<ReactMapGL>` component without any transformation.
-
-You can even use the package [redux-map-gl](https://github.com/Willyham/redux-map-gl) to save you some writing.


### PR DESCRIPTION
This library hasn't been updated in three years and appears to no longer be actively maintained. It has fallen out of sync with changes made to react-map-gl. For example, the width and height props are still considered separate props and are not part of the viewport state, like they are in react-map-gl.