### PR TITLE
Force map rerender synchronously after props update

### DIFF
--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -222,6 +222,7 @@ export default class Mapbox {
     // map render will throw error if style is not loaded
     if (map.isStyleLoaded()) {
       map._render();
+      // cancel the scheduled update
       if (map._frame) {
         map._frame.cancel();
         map._frame = null;


### PR DESCRIPTION
The synchronization issue is illustrated below, where the "SF" text is rendered using the React Marker component: (exaggerated by throttling the CPU)
![react-map-synchronization-issue](https://user-images.githubusercontent.com/2059298/52306730-93c6a300-294d-11e9-9436-bab12b50ece6.gif)

The problem: when the viewport updates, we call `Map.jumpTo()` inside `componentDidUpdate()`, which schedules a Mapbox rerender in the next animation frame. This causes the canvas rerender to always occur one step behind the React updates.

This is one step to fixing https://github.com/uber/deck.gl/issues/2458. Currently, there are three independent asynchronous update cycles: React, Mapbox and Deck. When props are updated inside a React lifecycle, Mapbox and Deck should immediately redraw instead of deferring to their own animation loops.
