### PR TITLE
doc: fix the value type of circle-radius

### DIFF
--- a/docs/get-started/adding-custom-data.md
+++ b/docs/get-started/adding-custom-data.md
@@ -26,7 +26,7 @@ const mapStyle = fromJS({
             source: 'points',
             paint: {
                 'circle-color': '#f00',
-                'circle-radius': '4'
+                'circle-radius': 4
             }
         }
     ]


### PR DESCRIPTION
Hi,

Really thanks for the nice component suite. It's quite useful and graceful~

However, when I refer to the example of [Adding Custom Data](https://uber.github.io/react-map-gl/#/Documentation/getting-started/adding-custom-data). I got a little problem. And find this little bug in example code:

The value of circle-radius should be a number.

And when setting as a string, it will break as throw an error like this:
```
Error: layers[0].paint.circle-radius: number expected, string found
    at Object.Jr [as emitValidationErrors] (webpack-internal:///./node_modules/mapbox-gl/dist/mapbox-gl.js:6005)
    at De (webpack-internal:///./node_modules/mapbox-gl/dist/mapbox-gl.js:18388)
    at i._load (webpack-internal:///./node_modules/mapbox-gl/dist/mapbox-gl.js:18441)
    at eval (webpack-internal:///./node_modules/mapbox-gl/dist/mapbox-gl.js:18436)
```

