### PR TITLE
Fix static context bug

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -258,27 +258,27 @@ export default class StaticMap extends PureComponent<StaticMapProps, State> {
     } = dimensions;
     this._updateMapSize(width, height);
 
-    const staticContext = {
-      // $FlowFixMe
-      viewport: new WebMercatorViewport(Object.assign({}, this.props, this.props.viewState, {
-        width,
-        height
-      })),
-      map: this._map,
-      mapContainer: this._mapContainerRef.current
-    };
+    return createElement(MapContext.Consumer, null, interactiveContext => {
+      const context = Object.assign({}, interactiveContext, {
+        // $FlowFixMe
+        viewport: new WebMercatorViewport(Object.assign({}, this.props, this.props.viewState, {
+          width,
+          height
+        })),
+        map: this._map,
+        mapContainer: interactiveContext.mapContainer || this._mapContainerRef.current
+      });
 
-    return createElement(MapContext.Consumer, null, interactiveContext =>
-      createElement(MapContext.Provider,
-        {value: Object.assign(staticContext, interactiveContext)},
+      return createElement(MapContext.Provider,
+        {value: context},
         createElement('div', {
           key: 'map-overlays',
           className: 'overlays',
           style: CONTAINER_STYLE,
           children: this.props.children
         })
-      )
-    );
+      );
+    });
   }
 
   render() {


### PR DESCRIPTION
When `StaticMap` is used standalone, default context props should not override local context.

For https://github.com/uber/react-map-gl/issues/747