### PR TITLE
Fix: popup close button click event propagates to map

### DIFF
--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -141,7 +141,8 @@ export default class Popup extends BaseControl {
       evt.stopPropagation();
     }
 
-    if (this.props.closeOnClick || evt.target.className === 'mapboxgl-popup-close-button') {
+    if (evt.type === 'click' &&
+      (this.props.closeOnClick || evt.target.className === 'mapboxgl-popup-close-button')) {
       this.props.onClose();
     }
   }


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/746

Introduced by #628 - `Popup._onClick` is now called twice (immediate click and single click). The popup should be closed on `click` event only.