### PR TITLE
Fix geolocate control marker styling

### DIFF
--- a/docs/components/geolocate-control.md
+++ b/docs/components/geolocate-control.md
@@ -64,9 +64,11 @@ If true the Geolocate Control becomes a toggle button and when active the map wi
 
 By default a dot will be shown on the map at the user's location. Set to false to disable.
 
-##### `style` {Object} - default: `{position: absolute, top: 0, right: 0, margin: 10}`
+##### `style` {Object} - default: `{}` 
 
 A [React style](https://reactjs.org/docs/dom-elements.html#style) object applied to Geolocate control button.
+
+Check [`locate user`](https://github.com/uber/react-map-gl/blob/master/examples/locate-user/src/app.js) example for basic styling.
 
 ## Styling
 

--- a/docs/components/geolocate-control.md
+++ b/docs/components/geolocate-control.md
@@ -28,13 +28,11 @@ class Map extends Component {
     const {viewport} = this.state;
     return (
       <ReactMapGL {...viewport} onViewportChange={updateViewport}>
-        <div style={{ position: "absolute", right: 0 }}>
-          <GeolocateControl 
-            positionOptions={{enableHighAccuracy: true}}
-            trackUserLocation={true}
-            onViewportChange={this._updateViewport}
-          />
-        </div>
+        <GeolocateControl 
+          positionOptions={{enableHighAccuracy: true}}
+          trackUserLocation={true}
+          onViewportChange={this._updateViewport}
+        />
       </ReactMapGL>
     );
   }
@@ -65,6 +63,10 @@ If  true the Geolocate Control becomes a toggle button and when active the map w
 ##### `showUserLocation` {Boolean} - default: `true`
 
 By default a dot will be shown on the map at the user's location. Set to false to disable.
+
+##### `containerStyle` {Object} - default: `{position: absolute, top: 0, right: 0, margin: 10}`
+
+[React style object](https://reactjs.org/docs/dom-elements.html#style) will be applied to Geolocate control button.
 
 ## Styling
 

--- a/docs/components/geolocate-control.md
+++ b/docs/components/geolocate-control.md
@@ -54,19 +54,19 @@ A Geolocation API [PositionOptions](https://developer.mozilla.org/en-US/docs/Web
 
 ##### `fitBoundsOptions` {Object} - default: `{maxZoom: 15}`
 
-A  [fitBounds](https://docs.mapbox.com/mapbox-gl-js/api/#map#fitbounds) options object to use when the map is panned and zoomed to the user's location. The default is to use a  maxZoom of 15 to limit how far the map will zoom in for very accurate locations.
+A [fitBounds](https://docs.mapbox.com/mapbox-gl-js/api/#map#fitbounds) options object to use when the map is panned and zoomed to the user's location. The default is to use a  maxZoom of 15 to limit how far the map will zoom in for very accurate locations.
 
 ##### `trackUserLocation` {Boolean} - default: `false`
 
-If  true the Geolocate Control becomes a toggle button and when active the map will receive updates to the user's location as it changes.
+If true the Geolocate Control becomes a toggle button and when active the map will receive updates to the user's location as it changes.
 
 ##### `showUserLocation` {Boolean} - default: `true`
 
 By default a dot will be shown on the map at the user's location. Set to false to disable.
 
-##### `containerStyle` {Object} - default: `{position: absolute, top: 0, right: 0, margin: 10}`
+##### `style` {Object} - default: `{position: absolute, top: 0, right: 0, margin: 10}`
 
-[React style object](https://reactjs.org/docs/dom-elements.html#style) will be applied to Geolocate control button.
+A [React style](https://reactjs.org/docs/dom-elements.html#style) object applied to Geolocate control button.
 
 ## Styling
 

--- a/examples/controls/src/app.js
+++ b/examples/controls/src/app.js
@@ -46,7 +46,7 @@ export default class App extends Component {
 
   _renderCityMarker = (city, index) => {
     return (
-      <Marker
+      <Marker 
         key={`marker-${index}`}
         longitude={city.longitude}
         latitude={city.latitude} >
@@ -59,13 +59,11 @@ export default class App extends Component {
     const {popupInfo} = this.state;
 
     return popupInfo && (
-      <Popup
-        tipSize={5}
+      <Popup tipSize={5}
         anchor="top"
         longitude={popupInfo.longitude}
         latitude={popupInfo.latitude}
-        closeOnClick={true}
-        captureClick={false}
+        closeOnClick={false}
         onClose={() => this.setState({popupInfo: null})} >
         <CityInfo info={popupInfo} />
       </Popup>

--- a/examples/controls/src/app.js
+++ b/examples/controls/src/app.js
@@ -46,7 +46,7 @@ export default class App extends Component {
 
   _renderCityMarker = (city, index) => {
     return (
-      <Marker 
+      <Marker
         key={`marker-${index}`}
         longitude={city.longitude}
         latitude={city.latitude} >
@@ -59,11 +59,13 @@ export default class App extends Component {
     const {popupInfo} = this.state;
 
     return popupInfo && (
-      <Popup tipSize={5}
+      <Popup
+        tipSize={5}
         anchor="top"
         longitude={popupInfo.longitude}
         latitude={popupInfo.latitude}
-        closeOnClick={false}
+        closeOnClick={true}
+        captureClick={false}
         onClose={() => this.setState({popupInfo: null})} >
         <CityInfo info={popupInfo} />
       </Popup>

--- a/examples/locate-user/src/app.js
+++ b/examples/locate-user/src/app.js
@@ -4,6 +4,13 @@ import MapGL, {GeolocateControl} from 'react-map-gl';
 
 const MAPBOX_TOKEN = ''; // Set your mapbox token here
 
+const geolocateStyle = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  margin: 10
+};
+
 export default class App extends Component {
 
   state = {
@@ -30,6 +37,7 @@ export default class App extends Component {
         onViewportChange={this._onViewportChange}
         mapboxApiAccessToken={MAPBOX_TOKEN}>
         <GeolocateControl
+          style={geolocateStyle}
           onViewportChange={this._onViewportChange}
           positionOptions={{enableHighAccuracy: true}}
           trackUserLocation={true}

--- a/examples/locate-user/src/app.js
+++ b/examples/locate-user/src/app.js
@@ -1,16 +1,8 @@
-/* global window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import MapGL, {GeolocateControl} from 'react-map-gl';
 
 const MAPBOX_TOKEN = ''; // Set your mapbox token here
-
-const geolocateStyle = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  padding: '10px'
-};
 
 export default class App extends Component {
 
@@ -37,13 +29,11 @@ export default class App extends Component {
         mapStyle="mapbox://styles/mapbox/dark-v9"
         onViewportChange={this._onViewportChange}
         mapboxApiAccessToken={MAPBOX_TOKEN}>
-        <div style={geolocateStyle}>
-          <GeolocateControl
-            onViewportChange={this._onViewportChange}
-            positionOptions={{enableHighAccuracy: true}}
-            trackUserLocation={true}
-          />
-        </div>
+        <GeolocateControl
+          onViewportChange={this._onViewportChange}
+          positionOptions={{enableHighAccuracy: true}}
+          trackUserLocation={true}
+        />
       </MapGL>
     );
   }

--- a/examples/locate-user/webpack.config.js
+++ b/examples/locate-user/webpack.config.js
@@ -22,8 +22,6 @@ const config = {
     app: resolve('./src/app.js')
   },
 
-  devtool: 'source-map',
-
   output: {
     library: 'App'
   },

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -31,6 +31,8 @@ const LOCAL_DEVELOPMENT_CONFIG = {
     }
   },
 
+  devtool: 'source-map',
+
   resolve: {
     alias: {
       // Imports the react-map-gl library from the src directory in this repo
@@ -60,6 +62,7 @@ function addLocalDevSettings(config) {
   config.resolve = config.resolve || {};
   config.resolve.alias = Object.assign({}, config.resolve.alias, LOCAL_DEVELOPMENT_CONFIG.resolve.alias);
   config.module.rules = config.module.rules.concat(LOCAL_DEVELOPMENT_CONFIG.module.rules);
+  config.devtool = LOCAL_DEVELOPMENT_CONFIG.devtool;
   return config;
 }
 

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -22,6 +22,7 @@ const LINEAR_TRANSITION_PROPS = Object.assign(
 const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Custom className
   className: PropTypes.string,
+  containerStyle: PropTypes.object,
 
   // mapbox geolocate options
   // https://docs.mapbox.com/mapbox-gl-js/api/#geolocatecontrol
@@ -38,6 +39,13 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 
 const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   className: '',
+  containerStyle: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    margin: '10px'
+  },
+
   // mapbox geolocate options
   positionOptions: null,
   fitBoundsOptions: null,
@@ -208,18 +216,16 @@ export default class GeolocateControl extends BaseControl {
       return null;
     }
 
-    const {className} = this.props;
-    return createElement(
-      'div',
-      {
+    const {className, containerStyle} = this.props;
+    return createElement('div', {id: 'geolocate-control'}, [
+      this._renderMarker(),
+      createElement('div', {
         className: `mapboxgl-ctrl mapboxgl-ctrl-group ${className}`,
         ref: this._containerRef,
+        style: containerStyle,
         onContextMenu: e => e.preventDefault()
-      },
-      [
-        this._renderMarker(),
-        this._renderButton('geolocate', 'Geolocate', this._onClickGeolocate)
-      ]
+      }, this._renderButton('geolocate', 'Geolocate', this._onClickGeolocate)
+    )]
     );
   }
 }

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -39,12 +39,7 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 
 const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   className: '',
-  style: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    margin: '10px'
-  },
+  style: {},
 
   // mapbox geolocate options
   positionOptions: null,
@@ -217,7 +212,7 @@ export default class GeolocateControl extends BaseControl {
     }
 
     const {className, style} = this.props;
-    return createElement('div', {id: 'geolocate-control'}, [
+    return createElement('div', null, [
       this._renderMarker(),
       createElement('div', {
         className: `mapboxgl-ctrl mapboxgl-ctrl-group ${className}`,

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -22,7 +22,7 @@ const LINEAR_TRANSITION_PROPS = Object.assign(
 const propTypes = Object.assign({}, BaseControl.propTypes, {
   // Custom className
   className: PropTypes.string,
-  containerStyle: PropTypes.object,
+  style: PropTypes.object,
 
   // mapbox geolocate options
   // https://docs.mapbox.com/mapbox-gl-js/api/#geolocatecontrol
@@ -39,7 +39,7 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
 
 const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   className: '',
-  containerStyle: {
+  style: {
     position: 'absolute',
     top: 0,
     left: 0,
@@ -216,13 +216,13 @@ export default class GeolocateControl extends BaseControl {
       return null;
     }
 
-    const {className, containerStyle} = this.props;
+    const {className, style} = this.props;
     return createElement('div', {id: 'geolocate-control'}, [
       this._renderMarker(),
       createElement('div', {
         className: `mapboxgl-ctrl mapboxgl-ctrl-group ${className}`,
         ref: this._containerRef,
-        style: containerStyle,
+        style,
         onContextMenu: e => e.preventDefault()
       }, this._renderButton('geolocate', 'Geolocate', this._onClickGeolocate)
     )]


### PR DESCRIPTION
For #760

API change:
- `style`: a custom react style object apply to geolocate button
