### PR TITLE
Fix style diff warning when reusing map

### DIFF
--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -271,6 +271,8 @@ export default class Mapbox {
     // Step3: update style and call onload again
     if (props.mapStyle) {
       this._map.setStyle(props.mapStyle, {
+        // From the user's perspective, there's no "diffing" on initialization
+        // We always rebuild the style from scratch when creating a new Mapbox instance
         diff: false
       });
     }

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -22,7 +22,6 @@
 /* global window, process, HTMLCanvasElement */
 import PropTypes from 'prop-types';
 import {document} from '../utils/globals';
-import {normalizeStyle} from '../utils/style-utils';
 
 function noop() {}
 
@@ -271,7 +270,7 @@ export default class Mapbox {
 
     // Step3: update style and call onload again
     if (props.mapStyle) {
-      this._map.setStyle(normalizeStyle(props.mapStyle), {
+      this._map.setStyle(props.mapStyle, {
         diff: false
       });
     }

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -22,6 +22,7 @@
 /* global window, process, HTMLCanvasElement */
 import PropTypes from 'prop-types';
 import {document} from '../utils/globals';
+import {normalizeStyle} from '../utils/style-utils';
 
 function noop() {}
 
@@ -270,8 +271,8 @@ export default class Mapbox {
 
     // Step3: update style and call onload again
     if (props.mapStyle) {
-      this._map.setStyle(props.mapStyle, {
-        diff: true
+      this._map.setStyle(normalizeStyle(props.mapStyle), {
+        diff: false
       });
     }
 


### PR DESCRIPTION
Always set style from scratch when creating a new `Mapbox` instance from a recycled `Map`