### PR TITLE
Viewport flyTo Interpolation: add support for auto duration and other options.

### DIFF
--- a/docs/advanced/viewport-transition.md
+++ b/docs/advanced/viewport-transition.md
@@ -112,7 +112,7 @@ Remarks:
   + `transitionEasing`
   + `transitionInterruption`
 - The default interaction/transition behavior can always be intercepted and overwritten in the handler for `onViewportChange`. However, if a transition is in progress, the properties that are being transitioned (e.g. longitude and latitude) should not be manipulated, otherwise the change will be interpreted as an interruption of the transition.
-- When using `FlyToInterpolator` for `transitionInterpolator`, `transitionDuration` can be set to `auto` where actual duration is auto calculated based on start and end viewports and is linear to the distance between them. This duration can be further customized using `speed` parameter to `FlyToInterpolator` constructor.
+- When using `FlyToInterpolator` for `transitionInterpolator`, `transitionDuration` can be set to `'auto'` where actual duration is auto calculated based on start and end viewports and is linear to the distance between them. This duration can be further customized using `speed` parameter to `FlyToInterpolator` constructor.
 
 
 ## Transition Interpolators

--- a/docs/advanced/viewport-transition.md
+++ b/docs/advanced/viewport-transition.md
@@ -112,6 +112,7 @@ Remarks:
   + `transitionEasing`
   + `transitionInterruption`
 - The default interaction/transition behavior can always be intercepted and overwritten in the handler for `onViewportChange`. However, if a transition is in progress, the properties that are being transitioned (e.g. longitude and latitude) should not be manipulated, otherwise the change will be interpreted as an interruption of the transition.
+- When using `FlyToInterpolator` for `transitionInterpolator`, `transitionDuration` can be set to `auto` where actual duration is auto calculated based on start and end viewports and is linear to the distance between them. This duration can be further customized using `speed` parameter to `FlyToInterpolator` constructor.
 
 
 ## Transition Interpolators

--- a/docs/components/fly-to-interpolator.md
+++ b/docs/components/fly-to-interpolator.md
@@ -19,7 +19,11 @@ import ReactMapGL, {FlyToInterpolator} from 'react-map-gl';
 
 Parameters:
 - `options` {Object} (optional)
-  + `speed` {Number} (optional, default 1.2) - Controls the `transitionDuration` calculated when it is set to `auto`, higher speed results in shorter duration and vice versa.
+  + `curve` (Number, optional, default: 1.414) - The zooming "curve" that will occur along the flight path.
+  - `speed` (Number, optional, default: 1.2) - The average speed of the animation defined in relation to `options.curve`, it linearly affects the duration, higher speed returns smaller durations and vice versa.
+  - `screenSpeed` (Number, optional) - The average speed of the animation measured in screenfuls per second. Similar to `opts.speed` it linearly affects the duration,  when specified `opts.speed` is ignored.
+  - `maxDuration` (Number, optional) - Maximum duration in milliseconds, if calculated duration exceeds this value, `0` is returned.
+
 
 
 ## Source

--- a/docs/components/fly-to-interpolator.md
+++ b/docs/components/fly-to-interpolator.md
@@ -15,9 +15,12 @@ import ReactMapGL, {FlyToInterpolator} from 'react-map-gl';
 
 ##### constructor
 
-`new FlyToInterpolator()`
+`new FlyToInterpolator([options])`
+
+Parameters:
+- `options` {Object} (optional)
+  + `speed` {Number} (optional, default 1.2) - Controls the `transitionDuration` calculated when it is set to `auto`, higher speed results in shorter duration and vice versa.
 
 
 ## Source
 [viewport-fly-to-interpolator.js](https://github.com/uber/react-map-gl/tree/5.0-release/src/utils/transition/viewport-fly-to-interpolator.js)
-

--- a/examples/viewport-animation/src/app.js
+++ b/examples/viewport-animation/src/app.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
-import MapGL, {FlyToInterpolator, TRANSITION_EVENTS} from 'react-map-gl';
+import MapGL, {FlyToInterpolator} from 'react-map-gl';
 
 import ControlPanel from './control-panel';
 
@@ -28,8 +28,7 @@ export default class App extends Component {
       latitude,
       zoom: 11,
       transitionInterpolator: new FlyToInterpolator({speed: 2}),
-      transitionDuration: 'auto',
-      transitionInterruption: TRANSITION_EVENTS.SNAP_TO_END
+      transitionDuration: 'auto'
     });
   };
 

--- a/examples/viewport-animation/src/app.js
+++ b/examples/viewport-animation/src/app.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
-import MapGL, {FlyToInterpolator} from 'react-map-gl';
+import MapGL, {FlyToInterpolator, TRANSITION_EVENTS} from 'react-map-gl';
 
 import ControlPanel from './control-panel';
 
@@ -27,8 +27,9 @@ export default class App extends Component {
       longitude,
       latitude,
       zoom: 11,
-      transitionInterpolator: new FlyToInterpolator(),
-      transitionDuration: 3000
+      transitionInterpolator: new FlyToInterpolator({speed: 2}),
+      transitionDuration: 'auto',
+      transitionInterruption: TRANSITION_EVENTS.SNAP_TO_END
     });
   };
 

--- a/flow-typed/npm/viewport-mercator-project_vx.x.x.js
+++ b/flow-typed/npm/viewport-mercator-project_vx.x.x.js
@@ -11,26 +11,43 @@ type Viewport = {
   bearing: number
 };
 
+type FlyToInterpolatorOpts = {
+  curve?: number,
+  speed?: number,
+  screenSpeed?: number,
+  maxDuraiton?: number
+};
+
 declare module 'viewport-mercator-project' {
   declare export class WebMercatorViewport {
-    constructor(Viewport) : WebMercatorViewport;
+    constructor(Viewport): WebMercatorViewport;
 
-    width: number,
-    height: number,
-    longitude: number,
-    latitude: number,
-    zoom: number,
-    pitch: number,
-    bearing: number,
+    width: number;
+    height: number;
+    longitude: number;
+    latitude: number;
+    zoom: number;
+    pitch: number;
+    bearing: number;
 
     project(xyz: Array<number>): Array<number>;
     unproject(xyz: Array<number>): Array<number>;
     getMapCenterByLngLatPosition({lngLat: Array<number>, pos: Array<number>}): Array<number>;
-    fitBounds(bounds: [[Number,Number],[Number,Number]], options: any): WebMercatorViewport;
+    fitBounds(bounds: [[Number, Number], [Number, Number]], options: any): WebMercatorViewport;
   }
 
-  declare export function normalizeViewportProps(props: Viewport) : Viewport;
-  declare export function flyToViewport(startProps: Viewport, endProps: Viewport, t: number) : Viewport;
+  declare export function normalizeViewportProps(props: Viewport): Viewport;
+  declare export function flyToViewport(
+    startProps: Viewport,
+    endProps: Viewport,
+    t: number,
+    opts?: FlyToInterpolatorOpts
+  ): Viewport;
+  declare export function getFlyToDuration(
+    startProps: Viewport,
+    endProps: Viewport,
+    opts?: FlyToInterpolatorOpts
+  ): number;
 
   declare export default typeof WebMercatorViewport;
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "publish-prod": "ocular-publish prod",
     "publish-beta": "ocular-publish beta",
     "test": "flow check && ocular-test",
+    "test-only": "ocular-test",
     "test-fast": "flow check && ocular-test fast",
     "metrics": "ocular-metrics",
     "update-release-branch": "scripts/update-release-branch.sh"
@@ -49,7 +50,7 @@
     "mjolnir.js": "^2.2.0",
     "prop-types": "^15.7.2",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "viewport-mercator-project": "^6.1.0"
+    "viewport-mercator-project": "^6.3.0-alpha.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "publish-prod": "ocular-publish prod",
     "publish-beta": "ocular-publish beta",
     "test": "flow check && ocular-test",
-    "test-only": "ocular-test",
     "test-fast": "flow check && ocular-test fast",
     "metrics": "ocular-metrics",
     "update-release-branch": "scripts/update-release-branch.sh"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mjolnir.js": "^2.2.0",
     "prop-types": "^15.7.2",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "viewport-mercator-project": "^6.3.0-alpha.0"
+    "viewport-mercator-project": "^6.2.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -39,7 +39,7 @@ const propTypes = Object.assign({}, StaticMap.propTypes, {
 
   /** Viewport transition **/
   // transition duration for viewport change
-  transitionDuration: PropTypes.number,
+  transitionDuration: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   // TransitionInterpolator instance, can be used to perform custom transitions.
   transitionInterpolator: PropTypes.object,
   // type of interruption of current transition on update.

--- a/src/utils/math-utils.js
+++ b/src/utils/math-utils.js
@@ -1,11 +1,12 @@
 // @flow
-const EPSILON = 1e-9;
+const EPSILON = 1e-7;
 
 // Returns true if value is either an array or a typed array
 function isArray(value: any): boolean {
   return Array.isArray(value) || ArrayBuffer.isView(value);
 }
 
+// TODO: use math.gl
 export function equals(a: any, b: any): boolean {
   if (a === b) {
     return true;

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -145,16 +145,6 @@ export default class TransitionManager {
     return false;
   }
 
-  _normalizeEndProps(nextProps: ViewportProps, startProps: ViewportProps): ViewportProps {
-    const endProps = Object.assign({}, nextProps);
-    const {transitionInterpolator} = nextProps;
-    if (transitionInterpolator) {
-      const transitionDuration = transitionInterpolator.getDuration(startProps, nextProps);
-      Object.assign(endProps, {transitionDuration});
-    }
-    return endProps;
-  }
-
   _shouldIgnoreViewportChange(currentProps: ViewportProps, nextProps: ViewportProps): boolean {
     if (!currentProps) {
       return true;
@@ -182,8 +172,9 @@ export default class TransitionManager {
       cancelAnimationFrame(this._animationFrame);
     }
 
-    // update transitionDuration for `auto` mode
-    endProps = this._normalizeEndProps(endProps, startProps);
+    // update transitionDuration for 'auto' mode
+    const {transitionInterpolator} = endProps;
+    const duration = transitionInterpolator.getDuration(startProps, endProps);
 
     const initialProps = endProps.transitionInterpolator.initializeProps(startProps, endProps);
 
@@ -197,7 +188,7 @@ export default class TransitionManager {
 
     this.state = {
       // Save current transition props
-      duration: endProps.transitionDuration,
+      duration,
       easing: endProps.transitionEasing,
       interpolator: endProps.transitionInterpolator,
       interruption: endProps.transitionInterruption,

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -84,14 +84,16 @@ export default class TransitionManager {
     // Set this.props here as '_triggerTransition' calls '_updateViewport' that uses this.props.
     this.props = nextProps;
 
+    // update transitionDuration for `auto` mode
+    const endProps = this._normalizeNextProps(nextProps, currentProps);
+
     // NOTE: Be cautious re-ordering statements in this function.
-    if (this._shouldIgnoreViewportChange(currentProps, nextProps)) {
+    if (this._shouldIgnoreViewportChange(currentProps, endProps)) {
       return false;
     }
 
-    if (this._isTransitionEnabled(nextProps)) {
+    if (this._isTransitionEnabled(endProps)) {
       const startProps = Object.assign({}, currentProps);
-      const endProps = Object.assign({}, nextProps);
 
       if (this._isTransitionInProgress()) {
         currentProps.onTransitionInterrupt();
@@ -140,6 +142,16 @@ export default class TransitionManager {
       return this.state.interpolator.arePropsEqual(props, this.state.propsInTransition);
     }
     return false;
+  }
+
+  _normalizeNextProps(nextProps: ViewportProps, startProps: ViewportProps): ViewportProps {
+    const endProps = Object.assign({}, nextProps);
+    const {transitionInterpolator} = nextProps;
+    if (transitionInterpolator) {
+      const transitionDuration = transitionInterpolator.getDuration(startProps, nextProps);
+      Object.assign(endProps, {transitionDuration});
+    }
+    return endProps;
   }
 
   _shouldIgnoreViewportChange(currentProps: ViewportProps, nextProps: ViewportProps): boolean {

--- a/src/utils/transition-manager.js
+++ b/src/utils/transition-manager.js
@@ -84,16 +84,14 @@ export default class TransitionManager {
     // Set this.props here as '_triggerTransition' calls '_updateViewport' that uses this.props.
     this.props = nextProps;
 
-    // update transitionDuration for `auto` mode
-    const endProps = this._normalizeNextProps(nextProps, currentProps);
-
     // NOTE: Be cautious re-ordering statements in this function.
-    if (this._shouldIgnoreViewportChange(currentProps, endProps)) {
+    if (this._shouldIgnoreViewportChange(currentProps, nextProps)) {
       return false;
     }
 
-    if (this._isTransitionEnabled(endProps)) {
+    if (this._isTransitionEnabled(nextProps)) {
       const startProps = Object.assign({}, currentProps);
+      const endProps = Object.assign({}, nextProps);
 
       if (this._isTransitionInProgress()) {
         currentProps.onTransitionInterrupt();
@@ -134,7 +132,10 @@ export default class TransitionManager {
   }
 
   _isTransitionEnabled(props: ViewportProps): boolean {
-    return props.transitionDuration > 0 && Boolean(props.transitionInterpolator);
+    const {transitionDuration, transitionInterpolator} = props;
+    return (
+      (transitionDuration > 0 || transitionDuration === 'auto') && Boolean(transitionInterpolator)
+    );
   }
 
   _isUpdateDueToCurrentTransition(props: ViewportProps): boolean {
@@ -144,7 +145,7 @@ export default class TransitionManager {
     return false;
   }
 
-  _normalizeNextProps(nextProps: ViewportProps, startProps: ViewportProps): ViewportProps {
+  _normalizeEndProps(nextProps: ViewportProps, startProps: ViewportProps): ViewportProps {
     const endProps = Object.assign({}, nextProps);
     const {transitionInterpolator} = nextProps;
     if (transitionInterpolator) {
@@ -180,6 +181,9 @@ export default class TransitionManager {
     if (this._animationFrame) {
       cancelAnimationFrame(this._animationFrame);
     }
+
+    // update transitionDuration for `auto` mode
+    endProps = this._normalizeEndProps(endProps, startProps);
 
     const initialProps = endProps.transitionInterpolator.initializeProps(startProps, endProps);
 

--- a/src/utils/transition/transition-interpolator.js
+++ b/src/utils/transition/transition-interpolator.js
@@ -47,4 +47,14 @@ export default class TransitionInterpolator {
   interpolateProps(startProps: any, endProps: any, t: number): any {
     assert(false, 'interpolateProps is not implemented');
   }
+
+  /**
+   * Returns transition duration
+   * @param startProps {object} - a list of starting viewport props
+   * @param endProps {object} - a list of target viewport props
+   * @returns {Number} - transition duration in milliseconds
+   */
+  getDuration(startProps: MapStateProps, endProps: MapStateProps) {
+    return endProps.transitionDuration;
+  }
 }

--- a/src/utils/transition/transition-interpolator.js
+++ b/src/utils/transition/transition-interpolator.js
@@ -1,6 +1,7 @@
 // @flow
 import {equals} from '../math-utils';
 import assert from '../assert';
+import type {MapStateProps} from '../map-state';
 
 export default class TransitionInterpolator {
   propNames: Array<string> = [];

--- a/src/utils/transition/viewport-fly-to-interpolator.js
+++ b/src/utils/transition/viewport-fly-to-interpolator.js
@@ -90,7 +90,7 @@ export default class ViewportFlyToInterpolator extends TransitionInterpolator {
   // computes the transition duration
   getDuration(startProps: MapStateProps, endProps: MapStateProps) {
     let {transitionDuration} = endProps;
-    if (typeof transitionDuration === 'string' && transitionDuration === 'auto') {
+    if (transitionDuration === 'auto') {
       // auto calculate duration based on start and end props
       transitionDuration = getFlyToDuration(startProps, endProps, this.props);
     }

--- a/src/utils/transition/viewport-fly-to-interpolator.js
+++ b/src/utils/transition/viewport-fly-to-interpolator.js
@@ -37,7 +37,7 @@ export default class ViewportFlyToInterpolator extends TransitionInterpolator {
 
   /**
    * @param props {Object}
-   - `props.curve` (Number, optional, default: 1.414) - The zooming "curve" that will occur along the flight path, .
+   - `props.curve` (Number, optional, default: 1.414) - The zooming "curve" that will occur along the flight path.
    - `props.speed` (Number, optional, default: 1.2) - The average speed of the animation defined in relation to `options.curve`, it linearly affects the duration, higher speed returns smaller durations and vice versa.
    - `props.screenSpeed` (Number, optional) - The average speed of the animation measured in screenfuls per second. Similar to `opts.speed` it linearly affects the duration,  when specified `opts.speed` is ignored.
    - `props.maxDuration` (Number, optional) - Maximum duration in milliseconds, if calculated duration exceeds this value, `0` is returned.

--- a/test/src/utils/transition/viewport-fly-to-interpolator.spec.js
+++ b/test/src/utils/transition/viewport-fly-to-interpolator.spec.js
@@ -2,6 +2,21 @@ import test from 'tape-catch';
 import {ViewportFlyToInterpolator} from 'react-map-gl/utils/transition';
 import {toLowPrecision} from 'react-map-gl/test/test-utils';
 
+const START_PROPS = {
+  width: 800,
+  height: 600,
+  longitude: -122.45,
+  latitude: 37.78,
+  zoom: 12
+};
+
+const END_PROPS = {
+  width: 800,
+  height: 600,
+  longitude: -74,
+  latitude: 40.7,
+  zoom: 11
+};
 /* eslint-disable max-len */
 const TEST_CASES = [
   {
@@ -12,20 +27,8 @@ const TEST_CASES = [
   },
   {
     title: 'optional prop fallback',
-    startProps: {
-      width: 800,
-      height: 600,
-      longitude: -122.45,
-      latitude: 37.78,
-      zoom: 12
-    },
-    endProps: {
-      width: 800,
-      height: 600,
-      longitude: -74,
-      latitude: 40.7,
-      zoom: 11
-    },
+    startProps: START_PROPS,
+    endProps: END_PROPS,
     expect: {
       start: {
         width: 800,
@@ -136,7 +139,32 @@ const TEST_CASES = [
 ];
 /* eslint-enable max-len */
 
-test('LinearInterpolator#initializeProps', t => {
+const DURATION_TEST_CASES = [
+  {
+    title: 'fixed duration',
+    endProps: {transitionDuration: 100},
+    expected: 100
+  },
+  {
+    title: 'auto duration',
+    endProps: {transitionDuration: 'auto'},
+    expected: 7325.794
+  },
+  {
+    title: 'high speed',
+    opts: {speed: 10},
+    endProps: {transitionDuration: 'auto'},
+    expected: 879.0953
+  },
+  {
+    title: 'high curve',
+    opts: {curve: 8},
+    endProps: {transitionDuration: 'auto'},
+    expected: 2016.924
+  }
+];
+
+test('ViewportFlyToInterpolator#initializeProps', t => {
   const interpolator = new ViewportFlyToInterpolator();
 
   TEST_CASES.forEach(testCase => {
@@ -152,7 +180,7 @@ test('LinearInterpolator#initializeProps', t => {
   t.end();
 });
 
-test('LinearInterpolator#interpolateProps', t => {
+test('ViewportFlyToInterpolator#interpolateProps', t => {
   const interpolator = new ViewportFlyToInterpolator();
 
   TEST_CASES.filter(testCase => testCase.transition).forEach(testCase => {
@@ -166,5 +194,20 @@ test('LinearInterpolator#interpolateProps', t => {
     });
   });
 
+  t.end();
+});
+
+test('ViewportFlyToInterpolator#getDuration', t => {
+  DURATION_TEST_CASES.forEach(testCase => {
+    const interpolator = new ViewportFlyToInterpolator(testCase.opts);
+    t.equal(
+      toLowPrecision(
+        interpolator.getDuration(START_PROPS, Object.assign({}, END_PROPS, testCase.endProps)),
+        7
+      ),
+      testCase.expected,
+      `${testCase.title}: should receive correct duration`
+    );
+  });
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9392,10 +9392,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viewport-mercator-project@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#d7b2cb3cb772b819f1daab17cf4019102a9102a6"
-  integrity sha512-nI0GEmXnESwZxWSJuaQkdCnvOv6yckUfqqFbNB8KWVbQY3eUExVM4ZziqCVVs5mNznLjDF1auj6HLW5D5DKcng==
+viewport-mercator-project@^6.3.0-alpha.0:
+  version "6.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.3.0-alpha.0.tgz#d72e4dcfc281870a80afaf356327db48e52898f0"
+  integrity sha512-ZMaJC0wt12/j9LHE9WFCVvwxJ8xK9iklGHCwHiwZZ52iwwMoEQW9QeSpi/dx5PfrfekaCFn4lkpQtEamLqNSBQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9392,10 +9392,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viewport-mercator-project@^6.3.0-alpha.0:
-  version "6.3.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.3.0-alpha.0.tgz#d72e4dcfc281870a80afaf356327db48e52898f0"
-  integrity sha512-ZMaJC0wt12/j9LHE9WFCVvwxJ8xK9iklGHCwHiwZZ52iwwMoEQW9QeSpi/dx5PfrfekaCFn4lkpQtEamLqNSBQ==
+viewport-mercator-project@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.2.1.tgz#4d4cf376bdcf027467d0417615a0257a6316e63c"
+  integrity sha512-Ns0KExngwGkX/QZCAzYbqh3TTI8LKeO8pOphZN4mZmp/+wO/HqDacbztwXMdrTLy57ToolT4XrAH2NhuK7Nyfw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"


### PR DESCRIPTION
For #865 
- Bump `viewport-mercator-poject` version
- Add support for `auto` duration
- Add support for `curve`, `speed`, `screenSpeed` and `maxDuration`
- Add docs and unit tests.