### PR TITLE
Add `updateMapStyle` prop

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -78,6 +78,7 @@ const propTypes = Object.assign({}, Mapbox.propTypes, {
 const defaultProps = Object.assign({}, Mapbox.defaultProps, {
   preventStyleDiffing: false,
   disableTokenWarning: false,
+  updateMapStyle: true,
   visible: true,
   onResize: noop,
   className: '',
@@ -107,7 +108,8 @@ export type StaticMapProps = {
   zoom: number,
   bearing: number,
   pitch: number,
-  altitude?: number
+  altitude?: number,
+  updateMapStyle: Boolean
 };
 
 type State = {
@@ -147,7 +149,7 @@ export default class StaticMap extends PureComponent<StaticMapProps, State> {
   }
 
   componentDidUpdate(prevProps: StaticMapProps) {
-    if (this._mapbox) {
+    if (this._mapbox && this.props.updateMapStyle) {
       this._updateMapStyle(prevProps, this.props);
       this._updateMapProps(this.props);
     }
@@ -199,7 +201,7 @@ export default class StaticMap extends PureComponent<StaticMapProps, State> {
   _updateMapStyle(oldProps: StaticMapProps, newProps: StaticMapProps) {
     const mapStyle = newProps.mapStyle;
     const oldMapStyle = oldProps.mapStyle;
-    if (mapStyle !== oldMapStyle) {
+    if (mapStyle !== oldMapStyle || !oldProps.updateMapStyle) {
       this._map.setStyle(normalizeStyle(mapStyle), {
         diff: !this.props.preventStyleDiffing
       });


### PR DESCRIPTION
This prop controls if map style should be updated on changes. Also
whilst this is true panning is disabled.

You might set this to false whilst integrating with mapbox-gl-draw.

The work is based off of the following issues:

- #725 - @ibgreen pointed out that this sort of prop would make for an
  easy integration.
- #450
- #328

## Context

At eAgronom, we tried out react-map-gl-draw but were forced to abandon it as it didn't yet support our needs. Re-reading the issues linked above, we've managed to build out a custom mapbox-gl-draw integration by:

- forking this library and adding the `updateMapStyle` prop.
- creating a custom react wrapper component which sets the following props on base map: `{ updateMapStyle: false, dragPan: false, onNativeClick: undefined, }`
- adding the following css to .overlays whilst drawing: `pointer-events: none`

## Questions to maintainers

I couldn't figure out how best cover this change with unit tests. We use [enzyme](https://airbnb.io/enzyme/) for similar purposes. Any pointers?