### PR TITLE
Fix crash during Source component removal

### DIFF
--- a/src/components/source.js
+++ b/src/components/source.js
@@ -48,7 +48,12 @@ export default class Source<Props: SourceProps> extends PureComponent<Props> {
   }
 
   componentWillUnmount() {
-    this._map.removeSource(this.id);
+    /* global requestAnimationFrame */
+    // Do not remove source immediately because the
+    // dependent <Layer>s' componentWillUnmount() might not have been called
+    // Removing source before dependent layers will throw error
+    // TODO - find a more robust solution
+    requestAnimationFrame(() => this._map.removeSource(this.id));
   }
 
   id: string;


### PR DESCRIPTION
This is a work around for https://github.com/uber/react-map-gl/issues/908

@MKaHead I would like to continue the conversation on https://github.com/uber/react-map-gl/pull/916 for a more robust solution.