### PR TITLE
Fix missing control icons when using mapbox-gl 1.6.0 (#952)

### DIFF
--- a/src/components/fullscreen-control.js
+++ b/src/components/fullscreen-control.js
@@ -113,7 +113,9 @@ export default class FullscreenControl extends BaseControl<
         type="button"
         title={label}
         onClick={callback}
-      />
+      >
+        <span className="mapboxgl-ctrl-icon" aria-hidden="true" />
+      </button>
     );
   }
 

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -211,7 +211,9 @@ export default class GeolocateControl extends BaseControl<
         type="button"
         title={label}
         onClick={callback}
-      />
+      >
+        <span className="mapboxgl-ctrl-icon" aria-hidden="true" />
+      </button>
     );
   };
 

--- a/src/components/navigation-control.js
+++ b/src/components/navigation-control.js
@@ -96,8 +96,16 @@ export default class NavigationControl extends BaseControl<
   _renderCompass() {
     const {bearing} = this._context.viewport;
     return (
-      <span className="mapboxgl-ctrl-compass-arrow" style={{transform: `rotate(${-bearing}deg)`}} />
+      <span
+        className="mapboxgl-ctrl-icon"
+        aria-hidden="true"
+        style={{transform: `rotate(${-bearing}deg)`}}
+      />
     );
+  }
+
+  _renderIcon() {
+    return <span className="mapboxgl-ctrl-icon" aria-hidden="true" />;
   }
 
   _renderButton(type: string, label: string, callback: Function, children: any) {
@@ -119,8 +127,9 @@ export default class NavigationControl extends BaseControl<
 
     return (
       <div className={`mapboxgl-ctrl mapboxgl-ctrl-group ${className}`} ref={this._containerRef}>
-        {showZoom && this._renderButton('zoom-in', 'Zoom In', this._onZoomIn)}
-        {showZoom && this._renderButton('zoom-out', 'Zoom Out', this._onZoomOut)}
+        {showZoom && this._renderButton('zoom-in', 'Zoom In', this._onZoomIn, this._renderIcon())}
+        {showZoom &&
+          this._renderButton('zoom-out', 'Zoom Out', this._onZoomOut, this._renderIcon())}
         {showCompass &&
           this._renderButton('compass', 'Reset North', this._onResetNorth, this._renderCompass())}
       </div>


### PR DESCRIPTION
Adds necessary span.mapboxgl-ctrl-icon to each button but leaves the .mapboxgl-ctrl-icon class on the button too for backwards compat with versions less than 1.6.0.

I tried to test the examples with controls after force installing mapbox-gl 1.5.1 and 1.6.0 and it appeared to work in both. However, I'm not 100% confident of the mapbox-gl versions that actually got bundled by Webpack though, as the dep interactions are quite complex (and I don't know of a way to check the loaded version in the JS console).

Resolves #952.