### PR TITLE
Fix React state update warning

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -245,6 +245,10 @@ export default class InteractiveMap extends PureComponent<InteractiveMapProps, S
     this._updateInteractiveContext({mapContainer});
   }
 
+  componentDidUpdate() {
+    this._setControllerProps(this.props);
+  }
+
   componentWillUnmount() {
     this._eventManager.destroy();
   }
@@ -489,8 +493,6 @@ export default class InteractiveMap extends PureComponent<InteractiveMapProps, S
   };
 
   render() {
-    this._setControllerProps(this.props);
-
     const {width, height, style, getCursor} = this.props;
 
     const eventCanvasStyle = Object.assign({position: 'relative'}, style, {

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -91,7 +91,8 @@ const defaultProps = {
   latitude: 0,
   zoom: 0,
   bearing: 0,
-  pitch: 0
+  pitch: 0,
+  altitude: 1.5
 };
 
 type MapboxGL = {

--- a/src/utils/map-controller.js
+++ b/src/utils/map-controller.js
@@ -135,7 +135,7 @@ export default class MapController {
   /* Callback util */
   // formats map state and invokes callback function
   updateViewport(newMapState: MapState, extraProps: any = {}, extraState: any = {}) {
-    const oldViewport = this.mapState ? this.mapState.getViewportProps() : {};
+    const oldViewport = this.mapState ? this.mapState.getViewportProps() : this.mapStateProps;
     const newViewport = Object.assign({}, newMapState.getViewportProps(), extraProps);
 
     const viewStateChanged = Object.keys(newViewport).some(
@@ -176,12 +176,14 @@ export default class MapController {
     this.onViewportChange = onViewportChange;
     this.onStateChange = onStateChange;
 
-    if (!this.mapStateProps || this.mapStateProps.height !== options.height) {
+    const dimensionChanged = !this.mapStateProps || this.mapStateProps.height !== options.height;
+
+    this.mapStateProps = options;
+
+    if (dimensionChanged) {
       // Dimensions changed, normalize the props
       this.updateViewport(new MapState(options));
     }
-
-    this.mapStateProps = options;
     // Update transition
     this._transitionManager.processViewportChange(
       Object.assign({}, options, {


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/872

- Avoid calling `onViewportChange` during `render` (move to `componentDidUpdate`)
- Fix an issue during initial `MapController.setOptions` -- we were always calling `onViewportChange` because `oldViewport` was empty.