### PR TITLE
Add clusters example

### DIFF
--- a/examples/clusters/README.md
+++ b/examples/clusters/README.md
@@ -1,0 +1,9 @@
+<div align="center">
+  <img src="https://avatars3.githubusercontent.com/u/2105791?v=3&s=200" />
+</div>
+
+## Example: Supercluster
+
+This app reproduces Mapbox's [Create and style clusters](https://docs.mapbox.com/mapbox-gl-js/example/cluster/) example.
+
+This example showcases how to visualize points as clusters.

--- a/examples/clusters/app.css
+++ b/examples/clusters/app.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  background: #000;
+}
+#map {
+  width: 100vw;
+  height: 100vh;
+}
+
+.control-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  max-width: 320px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  padding: 12px 24px;
+  margin: 20px;
+  font-size: 13px;
+  line-height: 2;
+  color: #6b6b76;
+  text-transform: uppercase;
+  outline: none;
+}

--- a/examples/clusters/index.html
+++ b/examples/clusters/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>react-map-gl Example</title>
+    <link rel="stylesheet" type="text/css" href="app.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src='app.js'></script>
+  </body>
+  <script type="text/javascript">
+    App.renderToDom(document.getElementById('map'));
+  </script>
+</html>

--- a/examples/clusters/package.json
+++ b/examples/clusters/package.json
@@ -1,0 +1,21 @@
+{
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
+  },
+  "dependencies": {
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
+    "react-map-gl": "^5.1.0-alpha"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.0",
+    "webpack": "^4.20.0",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.0"
+  }
+}

--- a/examples/clusters/src/app.js
+++ b/examples/clusters/src/app.js
@@ -1,0 +1,78 @@
+import React, {Component} from 'react';
+import {render} from 'react-dom';
+import MapGL, {Source, Layer} from 'react-map-gl';
+
+import ControlPanel from './control-panel';
+import {clusterLayer, clusterCountLayer, unclusteredPointLayer} from './layers';
+
+const MAPBOX_TOKEN = ''; // Set your mapbox token here
+
+export default class App extends Component {
+  state = {
+    viewport: {
+      latitude: 40.67,
+      longitude: -103.59,
+      zoom: 3,
+      bearing: 0,
+      pitch: 0
+    }
+  };
+
+  _sourceRef = React.createRef();
+
+  _onViewportChange = viewport => this.setState({viewport});
+
+  _onClick = event => {
+    const feature = event.features[0];
+    const clusterId = feature.properties.cluster_id;
+
+    const mapboxSource = this._sourceRef.current.getSource();
+
+    mapboxSource.getClusterExpansionZoom(clusterId, (err, zoom) => {
+      if (err) return;
+
+      this._onViewportChange({
+        ...this.state.viewport,
+        longitude: feature.geometry.coordinates[0],
+        latitude: feature.geometry.coordinates[1],
+        zoom,
+        transitionDuration: 500
+      });
+    });
+  };
+
+  render() {
+    const {viewport} = this.state;
+
+    return (
+      <MapGL
+        {...viewport}
+        width="100%"
+        height="100%"
+        mapStyle="mapbox://styles/mapbox/dark-v9"
+        onViewportChange={this._onViewportChange}
+        mapboxApiAccessToken={MAPBOX_TOKEN}
+        interactiveLayerIds={[clusterLayer.id]}
+        onClick={this._onClick}
+      >
+        <Source
+          type="geojson"
+          data="https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"
+          cluster={true}
+          clusterMaxZoom={14}
+          clusterRadius={50}
+          ref={this._sourceRef}
+        >
+          <Layer {...clusterLayer} />
+          <Layer {...clusterCountLayer} />
+          <Layer {...unclusteredPointLayer} />
+        </Source>
+        <ControlPanel containerComponent={this.props.containerComponent} />
+      </MapGL>
+    );
+  }
+}
+
+export function renderToDom(container) {
+  render(<App />, container);
+}

--- a/examples/clusters/src/app.js
+++ b/examples/clusters/src/app.js
@@ -29,7 +29,9 @@ export default class App extends Component {
     const mapboxSource = this._sourceRef.current.getSource();
 
     mapboxSource.getClusterExpansionZoom(clusterId, (err, zoom) => {
-      if (err) return;
+      if (err) {
+        return;
+      }
 
       this._onViewportChange({
         ...this.state.viewport,

--- a/examples/clusters/src/control-panel.js
+++ b/examples/clusters/src/control-panel.js
@@ -1,0 +1,24 @@
+import React, {PureComponent} from 'react';
+
+const defaultContainer = ({children}) => <div className="control-panel">{children}</div>;
+
+export default class ControlPanel extends PureComponent {
+  render() {
+    const Container = this.props.containerComponent || defaultContainer;
+
+    return (
+      <Container>
+        <h3>Create and Style Clusters</h3>
+        <p>Use Mapbox GL JS' built-in functions to visualize points as clusters.</p>
+        <div className="source-link">
+          <a
+            href="https://github.com/uber/react-map-gl/tree/5.0-release/examples/clusters"
+            target="_new"
+          >
+            View Code ↗
+          </a>
+        </div>
+      </Container>
+    );
+  }
+}

--- a/examples/clusters/src/layers.js
+++ b/examples/clusters/src/layers.js
@@ -1,0 +1,51 @@
+export const clusterLayer = {
+  id: 'clusters',
+  type: 'circle',
+  source: 'earthquakes',
+  filter: ['has', 'point_count'],
+  paint: {
+    'circle-color': [
+      'step',
+      ['get', 'point_count'],
+      '#51bbd6',
+      100,
+      '#f1f075',
+      750,
+      '#f28cb1'
+    ],
+    'circle-radius': [
+      'step',
+      ['get', 'point_count'],
+      20,
+      100,
+      30,
+      750,
+      40
+    ]
+  }
+};
+ 
+export const clusterCountLayer = {
+  id: 'cluster-count',
+  type: 'symbol',
+  source: 'earthquakes',
+  filter: ['has', 'point_count'],
+  layout: {
+    'text-field': '{point_count_abbreviated}',
+    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+    'text-size': 12
+  }
+};
+ 
+export const unclusteredPointLayer = {
+  id: 'unclustered-point',
+  type: 'circle',
+  source: 'earthquakes',
+  filter: ['!', ['has', 'point_count']],
+  paint: {
+    'circle-color': '#11b4da',
+    'circle-radius': 4,
+    'circle-stroke-width': 1,
+    'circle-stroke-color': '#fff'
+  }
+};

--- a/examples/clusters/src/layers.js
+++ b/examples/clusters/src/layers.js
@@ -4,27 +4,11 @@ export const clusterLayer = {
   source: 'earthquakes',
   filter: ['has', 'point_count'],
   paint: {
-    'circle-color': [
-      'step',
-      ['get', 'point_count'],
-      '#51bbd6',
-      100,
-      '#f1f075',
-      750,
-      '#f28cb1'
-    ],
-    'circle-radius': [
-      'step',
-      ['get', 'point_count'],
-      20,
-      100,
-      30,
-      750,
-      40
-    ]
+    'circle-color': ['step', ['get', 'point_count'], '#51bbd6', 100, '#f1f075', 750, '#f28cb1'],
+    'circle-radius': ['step', ['get', 'point_count'], 20, 100, 30, 750, 40]
   }
 };
- 
+
 export const clusterCountLayer = {
   id: 'cluster-count',
   type: 'symbol',
@@ -36,7 +20,7 @@ export const clusterCountLayer = {
     'text-size': 12
   }
 };
- 
+
 export const unclusteredPointLayer = {
   id: 'unclustered-point',
   type: 'circle',

--- a/examples/clusters/webpack.config.js
+++ b/examples/clusters/webpack.config.js
@@ -1,0 +1,47 @@
+// NOTE: To use this example standalone (e.g. outside of repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
+const resolve = require('path').resolve;
+const webpack = require('webpack');
+
+const BABEL_CONFIG = {
+  presets: ['@babel/env', '@babel/react'],
+  plugins: ['@babel/proposal-class-properties']
+};
+
+const config = {
+  mode: 'development',
+
+  entry: {
+    app: resolve('./src/app.js')
+  },
+
+  output: {
+    library: 'App'
+  },
+
+  module: {
+    rules: [
+      {
+        // Compile ES2015 using babel
+        test: /\.js$/,
+        include: [resolve('.')],
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: 'babel-loader',
+            options: BABEL_CONFIG
+          }
+        ]
+      }
+    ]
+  },
+
+  // Optional: Enables reading mapbox token from environment variable
+  plugins: [new webpack.EnvironmentPlugin(['MapboxAccessToken'])]
+};
+
+// Enables bundling against src in this repo rather than the installed version
+module.exports = env =>
+  env && env.local ? require('../webpack.config.local')(config)(env) : config;

--- a/examples/main/constants/toc.js
+++ b/examples/main/constants/toc.js
@@ -12,6 +12,7 @@ import CustomCursor from '../../custom-cursor/src/app';
 import DraggableMarker from '../../draggable-markers/src/app';
 import GeoJson from '../../geojson/src/app';
 import GeoJsonAnimation from '../../geojson-animation/src/app';
+import Clusters from '../../clusters/src/app';
 import LocateUser from '../../locate-user/src/app';
 import Interaction from '../../interaction/src/app';
 import Layers from '../../layers/src/app';
@@ -56,6 +57,11 @@ export const standaloneExamples = [
     path: 'geojsonAnimationExample',
     name: 'GeoJSON Animation',
     component: GeoJsonAnimation
+  },
+  {
+    path: 'clustersExample',
+    name: 'Clusters',
+    component: Clusters
   },
   {
     path: 'locateUserExample',


### PR DESCRIPTION
Reproduces Mapbox's [Create and style clusters](https://docs.mapbox.com/mapbox-gl-js/example/cluster/) example.