### PR TITLE
Export MapState from index.js so it is available for import by consumers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export {
   ViewportFlyToInterpolator as FlyToInterpolator
 } from './utils/transition';
 export {default as MapController} from './utils/map-controller';
+export {default as MapState} from './utils/map-state';
 export {WebMercatorViewport} from 'viewport-mercator-project';
 
 // Experimental Features (May change in minor version bumps, use at your own risk)


### PR DESCRIPTION
Currently, although MapState type is included in the typings, index.js doesn't actually export MapState and when a typescript using consumer imports it, editor does not complain but the build fails due to missing export statement. On the other hand, importing it directly from 'react-map-gl/src/utils/map-state' is not possible since typescript complains about types being missing.

So I added the missing import statement to the index.js file

I have also opened an issue to describe why it is necessary.

**MapState is not exported from index.js** #996