### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,7 +2,7 @@
 
 ## react-map-gl v5.2
 
-Release date: Jan 6, 2019
+Release date: Jan 6, 2020
 
 ### Highlights
 


### PR DESCRIPTION
Change the release date of react-map-gl v5.2 from Jan 6, 2019 to Jan 6, 2020.