### PR TITLE
Fix issue where translate by partial pixels causes blurry rendering

### DIFF
--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -21,6 +21,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DraggableControl from './draggable-control';
+import {crispPixel} from '../utils/crisp-pixel';
 
 import type {DraggableControlProps} from './draggable-control';
 
@@ -74,7 +75,7 @@ export default class Marker extends DraggableControl<MarkerProps> {
 
   _render() {
     const [x, y] = this._getPosition();
-    const transform = `translate(${x}px, ${y}px)`;
+    const transform = `translate(${crispPixel(x)}px, ${crispPixel(y)}px)`;
     const div = this._containerRef.current;
 
     if (this._control && div) {

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -25,6 +25,7 @@ import BaseControl from './base-control';
 import {getDynamicPosition, ANCHOR_POSITION} from '../utils/dynamic-position';
 
 import type {BaseControlProps} from './base-control';
+import {crispPercentage, crispPixel} from '../utils/crisp-pixel';
 import type {PositionType} from '../utils/dynamic-position';
 
 const propTypes = Object.assign({}, BaseControl.propTypes, {
@@ -135,11 +136,15 @@ export default class Popup extends BaseControl<PopupProps, *, HTMLDivElement> {
     const anchorPosition = ANCHOR_POSITION[positionType];
     const left = x + offsetLeft;
     const top = y + offsetTop;
+
+    const el = this._containerRef.current;
+    const xPercentage = crispPercentage(el, -anchorPosition.x * 100);
+    const yPercentage = crispPercentage(el, -anchorPosition.y * 100, 'y');
     const style = {
       position: 'absolute',
       transform: `
-        translate(${-anchorPosition.x * 100}%, ${-anchorPosition.y * 100}%)
-        translate(${left}px, ${top}px)
+        translate(${xPercentage}%, ${yPercentage}%)
+        translate(${crispPixel(left)}px, ${crispPixel(top)}px)
       `,
       display: undefined,
       zIndex: undefined

--- a/src/utils/crisp-pixel.js
+++ b/src/utils/crisp-pixel.js
@@ -1,0 +1,18 @@
+// @flow
+
+/* global window */
+const pixelRatio = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
+
+export const crispPixel = (size: number) => Math.round(size * pixelRatio) / pixelRatio;
+
+export const crispPercentage = (
+  el: null | HTMLDivElement,
+  percentage: number,
+  dimension: 'x' | 'y' = 'x'
+) => {
+  if (el === null) {
+    return percentage;
+  }
+  const origSize = dimension === 'x' ? el.offsetWidth : el.offsetHeight;
+  return (crispPixel((percentage / 100) * origSize) / origSize) * 100;
+};


### PR DESCRIPTION
https://github.com/uber/react-map-gl/issues/898#issuecomment-580899897

The core issue is positioning on decimal pixels. If you are on an older laptop (like a 2012 MacBook Air) you will have a 1x display, so half-pixels cause a huge problem. Even on brand new laptops (that have 2x and 3x displays) the partial pixels will cause the overlays to look blurry.

To really fix the issue you'd need to know the `offsetHeight` and `offsetWidth` as well as the `window.devicePixelRatio` to determine if the transform would cause the element to be rendered "blurry".