### PR TITLE
Bump dev tools

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,10 @@ module.exports = {
     'import/core-modules': [
       'math.gl',
       'viewport-mercator-project'
-    ]
+    ],
+    react: {
+      version: 'detect'
+    }
   },
   rules: {
     'guard-for-in': 0,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typecheck": "flow check",
-    "start": "(cd examples/main && yarn && yarn start-local)",
+    "start": "(cd examples/controls && yarn && yarn start-local)",
     "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
     "clean": "ocular-clean",
     "build": "ocular-clean && ocular-build",
@@ -70,7 +70,7 @@
     "flow-bin": "^0.98.1",
     "immutable": "^3.8.2",
     "jsdom": "^15.0.0",
-    "ocular-dev-tools": "^0.1.0",
+    "ocular-dev-tools": "^0.1.8",
     "pre-commit": "^1.2.2",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7041,10 +7041,10 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-ocular-dev-tools@^0.1.0:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.1.5.tgz#17986a8440689c1375e404318123b6a2adfff261"
-  integrity sha512-lFR+0CtH/lEicsyRosNUuOh+1bZdW+uCshoxaUz5WHSsO2qHBi6qrboHYTOA2EFn+jUwcEcrtDGHJEGh7xl1hA==
+ocular-dev-tools@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.1.8.tgz#da026de73fbe4e7aab1dc31339a5d83cf3c91839"
+  integrity sha512-ax/FXpqi9PtP1hzTdd+GlzTwscaChZdu7T/hqcHTvnCZf4PZluRuH/obIt+Ln31xl6eS2roCDt1pOsv5MSD70A==
   dependencies:
     "@babel/cli" "^7.0.0"
     "@babel/core" "^7.0.0"


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/1011

Removed jq dependency from ocular-dev-tools.