### PR TITLE
Fix invalid syntax in scale control docs

### DIFF
--- a/docs/api-reference/scale-control.md
+++ b/docs/api-reference/scale-control.md
@@ -14,7 +14,7 @@ class Map extends Component {
     return (
       <ReactMapGL {...viewport} onViewportChange={updateViewport}>
         <div style={{position: 'absolute', bottom: 100, left: 20}}>
-          <ScaleControl maxWidth={100} unit="metric"}/>
+          <ScaleControl maxWidth={100} unit="metric"/>
         </div>
       </ReactMapGL>
     );


### PR DESCRIPTION
This PR fixes a syntax error found in the [Scale Control docs](https://uber.github.io/react-map-gl/docs/api-reference/scale-control)