### PR TITLE
Fix usage of useState update function in examples

### DIFF
--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -28,7 +28,7 @@ function Map() {
   return (
     <ReactMapGL
       {...viewport}
-      onViewportChange={setViewport}
+      onViewportChange={nextViewport => setViewport(nextViewport)}
     />
   );
 }

--- a/examples/get-started/hooks/app.js
+++ b/examples/get-started/hooks/app.js
@@ -21,7 +21,7 @@ function Root() {
       width="100vw"
       height="100vh"
       mapStyle="mapbox://styles/mapbox/dark-v9"
-      onViewportChange={setViewport}
+      onViewportChange={nextViewport => setViewport(nextViewport)}
       mapboxApiAccessToken={MAPBOX_TOKEN}
     />
   );


### PR DESCRIPTION
This fixes a subtle issue in the examples of using the `useState` hook for managing the viewport state.

The examples pass the `useState` update function (`setViewport`) directly to the `onViewportChange` prop of `InteractiveMap`. When this approach is used, React outputs the following error whenever the map is interacted with:

> Warning: State updates from the useState() and useReducer() Hooks don't support the second callback argument. To execute a side effect after rendering, declare it in the component body with useEffect().

The reason this happens is because the `onViewportChange` prop expects a callback function that it [passes 3 arguments](https://github.com/uber/react-map-gl/blob/db766e30a581ff32a7c2f7a548aab3c9ad4ffcbd/src/components/interactive-map.js#L347) to: `onViewportChange(viewState, interactionState, oldViewState)`. As such, `setViewport` is called with these 3 arguments even though it expects just a single argument.

The proposed solution uses an inline function to pass *just* the argument we care about (`viewState`) to `setViewport`.