### PR TITLE
Fix Map component's child container style

### DIFF
--- a/modules/react-mapbox/src/components/map.tsx
+++ b/modules/react-mapbox/src/components/map.tsx
@@ -125,7 +125,7 @@ function _Map(props: MapProps, ref: React.Ref<MapRef>) {
 
   return (
     <div id={props.id} ref={containerRef} style={style}>
-      {mapInstance && (
+      {mapInstance && props.children && (
         <MapContext.Provider value={contextValue}>
           <div mapboxgl-children="" style={CHILD_CONTAINER_STYLE}>
             {props.children}

--- a/modules/react-maplibre/src/components/map.tsx
+++ b/modules/react-maplibre/src/components/map.tsx
@@ -126,7 +126,7 @@ function _Map(props: MapProps, ref: React.Ref<MapRef>) {
 
   return (
     <div id={props.id} ref={containerRef} style={style}>
-      {mapInstance && (
+      {mapInstance && props.children && (
         <MapContext.Provider value={contextValue}>
           <div mapboxgl-children="" style={CHILD_CONTAINER_STYLE}>
             {props.children}


### PR DESCRIPTION
https://github.com/visgl/react-map-gl/pull/2132 introduced a change where there is always a div rendered below the map component with the same height of the map. This can result in an empty div that obstructs other elements rendered below the map.

This PR makes two changes:
1. The child container div is only rendered if there are any children
2. Adds a prop to allow styling the child container