### PR TITLE
fix: Adjust formatting and linting for GlobeControl component

### DIFF
--- a/modules/react-maplibre/src/components/globe-control.ts
+++ b/modules/react-maplibre/src/components/globe-control.ts
@@ -1,8 +1,8 @@
-import * as React from "react";
-import { useEffect, memo } from "react";
-import { applyReactStyle } from "../utils/apply-react-style";
-import { useControl } from "./use-control";
-import { ControlPosition } from "../types/lib";
+import * as React from 'react';
+import {useEffect, memo} from 'react';
+import {applyReactStyle} from '../utils/apply-react-style';
+import {useControl} from './use-control';
+import {ControlPosition} from '../types/lib';
 
 export type GlobeControlProps = {
   /** Placement of the control relative to the map. */
@@ -12,8 +12,8 @@ export type GlobeControlProps = {
 };
 
 function _GlobeControl(props: GlobeControlProps) {
-  const ctrl = useControl(({ mapLib }) => new mapLib.GlobeControl(props), {
-    position: props.position,
+  const ctrl = useControl(({mapLib}) => new mapLib.GlobeControl(props), {
+    position: props.position
   });
 
   useEffect(() => {

--- a/modules/react-maplibre/src/types/lib.ts
+++ b/modules/react-maplibre/src/types/lib.ts
@@ -19,7 +19,7 @@ import type {
   TerrainSpecification,
   LogoControl,
   LogoControlOptions,
-  GlobeControl,
+  GlobeControl
 } from 'maplibre-gl';
 
 export type {


### PR DESCRIPTION
This pull request makes minor updates to the `react-maplibre` module, primarily focused on code style consistency and import/export cleanup.

Sorry for my mistake  🙇🙏 

related:
- https://github.com/visgl/react-map-gl/pull/2554

* Standardized all import statements in `globe-control.ts` to use single quotes for consistency.
* Minor formatting adjustment in the `useControl` call within `_GlobeControl` for style consistency.
* Cleaned up the import list in `lib.ts` by removing an unnecessary comma after `GlobeControl`.