### PR TITLE
fix(react-maplibre): guard against undefined map.style in _updateStyleComponents

### DIFF
--- a/modules/react-maplibre/src/maplibre/maplibre.ts
+++ b/modules/react-maplibre/src/maplibre/maplibre.ts
@@ -462,7 +462,7 @@ export default class Maplibre {
     const map = this._map;
     const currProps = this._styleComponents;
     // We can safely manipulate map style once it's loaded
-    if (map.style._loaded) {
+    if (map.style?._loaded) {
       if (light && !deepEqual(light, currProps.light)) {
         currProps.light = light;
         map.setLight(light);


### PR DESCRIPTION
## Summary

When using React 19's `<Activity>` component with `mode="hidden"`, the map can be in a partially initialized state when event handlers fire. This causes a `TypeError` when accessing `map.style._loaded` because `map.style` is undefined.

**Error:**
```
TypeError: undefined is not an object (evaluating 'map.style._loaded')
```

**The fix:** Add optional chaining (`map.style?._loaded`) to prevent the crash while maintaining the same logical behavior - if `map.style` is undefined, the condition is falsy and the style components won't be updated (which is the correct behavior when the map isn't fully initialized).

## Changes

- `modules/react-maplibre/src/maplibre/maplibre.ts`: Line 465 - changed `map.style._loaded` to `map.style?._loaded`

## Context

React 19's Activity component with `mode="hidden"`:
- Runs cleanup effects (like unmounting)
- Preserves React state
- When switching back to `mode="visible"`, effects run again

During this transition, internal map events (`style.load` or `sourcedata`) can fire and call `_updateStyleComponents` before the map is fully reinitialized, causing the null reference error.