### PR TITLE
fix: guard marker attachment when the canvas container is unavailable

### DIFF
--- a/modules/main/src/mapbox-legacy/components/marker.ts
+++ b/modules/main/src/mapbox-legacy/components/marker.ts
@@ -77,7 +77,14 @@ export const Marker = memo(
     }, []);
 
     useEffect(() => {
-      marker.addTo(map.getMap());
+      const mapInstance = map.getMap();
+      const canvasContainer = mapInstance?.getCanvasContainer?.();
+
+      if (!canvasContainer || !canvasContainer.isConnected) {
+        return undefined;
+      }
+
+      marker.addTo(mapInstance);
 
       return () => {
         marker.remove();

--- a/modules/main/test/components/index.js
+++ b/modules/main/test/components/index.js
@@ -3,5 +3,6 @@ import './controls.spec';
 import './source.spec';
 import './layer.spec';
 import './marker.spec';
+import './marker-lifecycle.spec';
 import './popup.spec';
 import './use-map.spec';

--- a/modules/main/test/components/marker-lifecycle.spec.jsx
+++ b/modules/main/test/components/marker-lifecycle.spec.jsx
@@ -1,0 +1,10 @@
+import test from 'tape-promise/tape';
+import {Marker} from 'react-map-gl/mapbox-legacy';
+
+import {MapContext} from '../../src/mapbox-legacy/components/map';
+import {testMissingCanvasContainer} from '../../../../test/helpers/marker-canvas-container-guard';
+
+test('Marker ignores maps whose canvas container is already unavailable', async t => {
+  await testMissingCanvasContainer(t, {MapContext, Marker});
+  t.end();
+});

--- a/modules/react-mapbox/src/components/marker.ts
+++ b/modules/react-mapbox/src/components/marker.ts
@@ -77,7 +77,14 @@ export const Marker = memo(
     }, []);
 
     useEffect(() => {
-      marker.addTo(map.getMap());
+      const mapInstance = map.getMap();
+      const canvasContainer = mapInstance?.getCanvasContainer?.();
+
+      if (!canvasContainer || !canvasContainer.isConnected) {
+        return undefined;
+      }
+
+      marker.addTo(mapInstance);
 
       return () => {
         marker.remove();

--- a/modules/react-mapbox/test/components/index.js
+++ b/modules/react-mapbox/test/components/index.js
@@ -3,5 +3,6 @@ import './controls.spec';
 import './source.spec';
 import './layer.spec';
 import './marker.spec';
+import './marker-lifecycle.spec';
 import './popup.spec';
 import './use-map.spec';

--- a/modules/react-mapbox/test/components/marker-lifecycle.spec.jsx
+++ b/modules/react-mapbox/test/components/marker-lifecycle.spec.jsx
@@ -1,0 +1,10 @@
+import test from 'tape-promise/tape';
+import {Marker} from '@vis.gl/react-mapbox';
+
+import {MapContext} from '../../src/components/map';
+import {testMissingCanvasContainer} from '../../../../test/helpers/marker-canvas-container-guard';
+
+test('Marker ignores maps whose canvas container is already unavailable', async t => {
+  await testMissingCanvasContainer(t, {MapContext, Marker});
+  t.end();
+});

--- a/modules/react-maplibre/src/components/marker.ts
+++ b/modules/react-maplibre/src/components/marker.ts
@@ -77,7 +77,14 @@ export const Marker = memo(
     }, []);
 
     useEffect(() => {
-      marker.addTo(map.getMap());
+      const mapInstance = map.getMap();
+      const canvasContainer = mapInstance?.getCanvasContainer?.();
+
+      if (!canvasContainer || !canvasContainer.isConnected) {
+        return undefined;
+      }
+
+      marker.addTo(mapInstance);
 
       return () => {
         marker.remove();

--- a/modules/react-maplibre/test/components/index.js
+++ b/modules/react-maplibre/test/components/index.js
@@ -3,5 +3,6 @@ import './controls.spec';
 import './source.spec';
 import './layer.spec';
 import './marker.spec';
+import './marker-lifecycle.spec';
 import './popup.spec';
 import './use-map.spec';

--- a/modules/react-maplibre/test/components/marker-lifecycle.spec.jsx
+++ b/modules/react-maplibre/test/components/marker-lifecycle.spec.jsx
@@ -1,0 +1,10 @@
+import test from 'tape-promise/tape';
+import {Marker} from '@vis.gl/react-maplibre';
+
+import {MapContext} from '../../src/components/map';
+import {testMissingCanvasContainer} from '../../../../test/helpers/marker-canvas-container-guard';
+
+test('Marker ignores maps whose canvas container is already unavailable', async t => {
+  await testMissingCanvasContainer(t, {MapContext, Marker});
+  t.end();
+});

--- a/test/helpers/marker-canvas-container-guard.jsx
+++ b/test/helpers/marker-canvas-container-guard.jsx
@@ -1,0 +1,143 @@
+/* global document, window, setTimeout */
+import * as React from 'react';
+import {createRoot} from 'react-dom/client';
+
+class MockMarker {
+  constructor(options = {}) {
+    this._element = options.element || document.createElement('div');
+    this._lngLat = {lng: 0, lat: 0};
+    this._offset = null;
+    this._draggable = false;
+    this._rotation = 0;
+    this._rotationAlignment = 'auto';
+    this._pitchAlignment = 'auto';
+    this._popup = null;
+    this._listeners = {};
+  }
+
+  addTo(map) {
+    this.remove();
+    this._map = map;
+    map.getCanvasContainer().appendChild(this._element);
+    return this;
+  }
+
+  remove() {
+    this._map = null;
+    return this;
+  }
+
+  setLngLat([lng, lat]) {
+    this._lngLat = {lng, lat};
+    return this;
+  }
+
+  getLngLat() {
+    return this._lngLat;
+  }
+
+  getElement() {
+    return this._element;
+  }
+
+  on(type, handler) {
+    this._listeners[type] = handler;
+    return this;
+  }
+
+  getOffset() {
+    return this._offset;
+  }
+
+  setOffset(offset) {
+    this._offset = offset;
+    return this;
+  }
+
+  isDraggable() {
+    return this._draggable;
+  }
+
+  setDraggable(draggable) {
+    this._draggable = draggable;
+    return this;
+  }
+
+  getRotation() {
+    return this._rotation;
+  }
+
+  setRotation(rotation) {
+    this._rotation = rotation;
+    return this;
+  }
+
+  getRotationAlignment() {
+    return this._rotationAlignment;
+  }
+
+  setRotationAlignment(rotationAlignment) {
+    this._rotationAlignment = rotationAlignment;
+    return this;
+  }
+
+  getPitchAlignment() {
+    return this._pitchAlignment;
+  }
+
+  setPitchAlignment(pitchAlignment) {
+    this._pitchAlignment = pitchAlignment;
+    return this;
+  }
+
+  getPopup() {
+    return this._popup;
+  }
+
+  setPopup(popup) {
+    this._popup = popup;
+    return this;
+  }
+
+  toggleClassName(className) {
+    this._element.classList.toggle(className);
+    return this;
+  }
+}
+
+export async function testMissingCanvasContainer(t, {MapContext, Marker}) {
+  const root = createRoot(document.createElement('div'));
+  const errors = [];
+  const originalError = window.onerror;
+
+  const mapValue = {
+    map: {
+      getMap: () => ({
+        getCanvasContainer: () => undefined
+      })
+    },
+    mapLib: {
+      Marker: MockMarker
+    }
+  };
+
+  window.onerror = event => {
+    errors.push(event?.error || event);
+    return true;
+  };
+
+  root.render(
+    <MapContext.Provider value={mapValue}>
+      <Marker longitude={-122} latitude={38}>
+        <div />
+      </Marker>
+    </MapContext.Provider>
+  );
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  window.onerror = originalError;
+  root.unmount();
+
+  t.deepEqual(errors, [], 'no addTo error is thrown');
+}


### PR DESCRIPTION
## Summary
- skip marker attachment when the underlying map canvas container is no longer available
- apply the guard consistently to the mapbox, maplibre, and mapbox-legacy marker implementations
- add browser regressions covering the unavailable-canvas-container case for all three marker components

## Testing
- targeted browser regression covering the new marker guard for mapbox, maplibre, and mapbox-legacy markers
- `node` test suite (runs from the commit hook)

Closes #2584.