### PR TITLE
Add `react-map-gl/mapbox-esm` entrypoint

### DIFF
--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -36,6 +36,8 @@ import * as React from 'react';
 import Map from 'react-map-gl/mapbox';
 // If using with mapbox-gl v1:
 // import Map from 'react-map-gl/mapbox-legacy';
+// To load mapbox-gl's ESM build by default (requires mapbox-gl v3.23+):
+// import Map from 'react-map-gl/mapbox-esm';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 function App() {

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -21,6 +21,11 @@
       "require": "./dist/mapbox.cjs",
       "import": "./dist/mapbox.js"
     },
+    "./mapbox-esm": {
+      "types": "./dist/mapbox-esm.d.ts",
+      "require": "./dist/mapbox-esm.cjs",
+      "import": "./dist/mapbox-esm.js"
+    },
     "./maplibre": {
       "types": "./dist/maplibre.d.ts",
       "require": "./dist/maplibre.cjs",
@@ -36,6 +41,9 @@
     "*": {
       "mapbox": [
         "./dist/mapbox.d.ts"
+      ],
+      "mapbox-esm": [
+        "./dist/mapbox-esm.d.ts"
       ],
       "maplibre": [
         "./dist/maplibre.d.ts"

--- a/modules/main/src/mapbox-esm.ts
+++ b/modules/main/src/mapbox-esm.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/no-unresolved */
+export * from '@vis.gl/react-mapbox/esm';
+
+export {Map as default} from '@vis.gl/react-mapbox/esm';

--- a/modules/main/src/mapbox-esm.ts
+++ b/modules/main/src/mapbox-esm.ts
@@ -1,4 +1,5 @@
-/* eslint-disable import/no-unresolved */
+// eslint-disable-next-line import/no-unresolved
 export * from '@vis.gl/react-mapbox/esm';
 
+// eslint-disable-next-line import/no-unresolved
 export {Map as default} from '@vis.gl/react-mapbox/esm';

--- a/modules/react-mapbox/package.json
+++ b/modules/react-mapbox/package.json
@@ -22,6 +22,18 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./esm": {
+      "import": "./dist/esm.js",
+      "require": "./dist/esm.cjs",
+      "types": "./dist/esm.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "esm": [
+        "./dist/esm.d.ts"
+      ]
     }
   },
   "files": [

--- a/modules/react-mapbox/src/components/map.tsx
+++ b/modules/react-mapbox/src/components/map.tsx
@@ -34,7 +34,11 @@ export type MapProps = MapInitOptions &
     children?: any;
   };
 
-function _Map(props: MapProps, ref: React.Ref<MapRef>) {
+function _Map(
+  props: MapProps,
+  ref: React.Ref<MapRef>,
+  loadMapLib: () => Promise<MapLib | {default: MapLib}>
+) {
   const mountedMapsContext = useContext(MountedMapsContext);
   const [mapInstance, setMapInstance] = useState<Mapbox>(null);
   const containerRef = useRef();
@@ -46,7 +50,7 @@ function _Map(props: MapProps, ref: React.Ref<MapRef>) {
     let isMounted = true;
     let mapbox: Mapbox;
 
-    Promise.resolve(mapLib || import('mapbox-gl'))
+    Promise.resolve(mapLib || loadMapLib())
       .then((module: MapLib | {default: MapLib}) => {
         if (!isMounted) {
           return;
@@ -133,4 +137,12 @@ function _Map(props: MapProps, ref: React.Ref<MapRef>) {
   );
 }
 
-export const Map = React.forwardRef(_Map);
+export function createMap(
+  loadMapLib: () => Promise<MapLib | {default: MapLib}> = () => import('mapbox-gl')
+) {
+  return React.forwardRef<MapRef, MapProps>(function Map(props, ref) {
+    return _Map(props, ref, loadMapLib);
+  });
+}
+
+export const Map = createMap();

--- a/modules/react-mapbox/src/esm.ts
+++ b/modules/react-mapbox/src/esm.ts
@@ -1,0 +1,7 @@
+export * from './index';
+
+import {createMap} from './components/map';
+
+// eslint-disable-next-line import/no-unresolved
+export const Map = createMap(() => import('mapbox-gl/esm'));
+export default Map;

--- a/modules/react-mapbox/src/esm.ts
+++ b/modules/react-mapbox/src/esm.ts
@@ -2,6 +2,7 @@ export * from './index';
 
 import {createMap} from './components/map';
 
+// `mapbox-gl/esm` requires mapbox-gl v3.23 or newer.
 // eslint-disable-next-line import/no-unresolved
 export const Map = createMap(() => import('mapbox-gl/esm'));
 export default Map;

--- a/modules/react-mapbox/src/mapbox-gl-esm.d.ts
+++ b/modules/react-mapbox/src/mapbox-gl-esm.d.ts
@@ -1,0 +1,2 @@
+export * from 'mapbox-gl';
+export {default} from 'mapbox-gl';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,9 @@
     "paths": {
       "react-map-gl": ["modules/main/src"],
       "@vis.gl/react-mapbox": ["modules/react-mapbox/src"],
-      "@vis.gl/react-maplibre": ["modules/react-maplibre/src"]
+      "@vis.gl/react-mapbox/esm": ["modules/react-mapbox/src/esm"],
+      "@vis.gl/react-maplibre": ["modules/react-maplibre/src"],
+      "mapbox-gl/esm": ["modules/react-mapbox/src/mapbox-gl-esm"]
     },
     "plugins": [
       {


### PR DESCRIPTION
Exposes Mapbox GL JS's new `mapbox-gl/esm` entrypoint.